### PR TITLE
fix: DateTime is always serialized into UTC

### DIFF
--- a/openapi-generator/src/main/resources/csharp/ApiClient.mustache
+++ b/openapi-generator/src/main/resources/csharp/ApiClient.mustache
@@ -32,7 +32,8 @@ namespace {{packageName}}.Client
     {
         private JsonSerializerSettings serializerSettings = new JsonSerializerSettings
         {
-            ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor
+            ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor,
+            DateTimeZoneHandling = DateTimeZoneHandling.Utc
         };
 
         /// <summary>
@@ -394,7 +395,7 @@ namespace {{packageName}}.Client
         {
             try
             {
-                return obj != null ? JsonConvert.SerializeObject(obj) : null;
+                return obj != null ? JsonConvert.SerializeObject(obj, serializerSettings) : null;
             }
             catch (Exception e)
             {


### PR DESCRIPTION
Related to https://github.com/influxdata/influxdb-client-csharp/pull/168