### PR TITLE
chore: allow setting shard-group durations for buckets API (https://g…

### DIFF
--- a/openapi-generator/src/main/resources/python/__init__package.mustache
+++ b/openapi-generator/src/main/resources/python/__init__package.mustache
@@ -17,6 +17,7 @@ from {{packageName}}.configuration import Configuration
 {{/model}}{{/models}}
 from influxdb_client.client.authorizations_api import AuthorizationsApi
 from influxdb_client.client.bucket_api import BucketsApi
+from influxdb_client.client.delete_api import DeleteApi
 from influxdb_client.client.labels_api import LabelsApi
 from influxdb_client.client.organizations_api import OrganizationsApi
 from influxdb_client.client.query_api import QueryApi

--- a/openapi-generator/src/main/resources/python/rest.mustache
+++ b/openapi-generator/src/main/resources/python/rest.mustache
@@ -10,7 +10,6 @@ import logging
 import re
 import ssl
 
-import certifi
 # python 2 and python 3 compatibility library
 import six
 from six.moves.urllib.parse import urlencode
@@ -77,8 +76,7 @@ class RESTClientObject(object):
         if configuration.ssl_ca_cert:
             ca_certs = configuration.ssl_ca_cert
         else:
-            # if not set certificate file, use Mozilla's root certificates.
-            ca_certs = certifi.where()
+            ca_certs = None
 
         addition_pool_args = {}
         if configuration.assert_hostname is not None:

--- a/swagger.yml
+++ b/swagger.yml
@@ -6825,9 +6825,13 @@ components:
                   - expire
               everySeconds:
                 type: integer
-                description: Duration in seconds for how long data will be kept in the database.
+                description: Duration in seconds for how long data will be kept in the database. 0 means infinite.
                 example: 86400
-                minimum: 1
+                minimum: 0
+              shardGroupDurationSeconds:
+                type: integer
+                format: int64
+                description: Shard duration measured in seconds.
             required: [type, everySeconds]
       required: [name, retentionRules]
     Bucket:
@@ -6900,9 +6904,13 @@ components:
                   - expire
               everySeconds:
                 type: integer
-                description: Duration in seconds for how long data will be kept in the database.
+                description: Duration in seconds for how long data will be kept in the database. 0 means infinite.
                 example: 86400
-                minimum: 1
+                minimum: 0
+              shardGroupDurationSeconds:
+                type: integer
+                format: int64
+                description: Shard duration measured in seconds.
             required: [type, everySeconds]
         labels:
           $ref: "#/components/schemas/Labels"


### PR DESCRIPTION
### 1. Swagger update
Related to https://github.com/influxdata/influxdb-client-python/pull/209

Added changes https://github.com/influxdata/influxdb/pull/20911:

![image](https://user-images.githubusercontent.com/455137/111181154-f8816c80-85ad-11eb-8aa5-dab07102fa7d.png)

### 2. Removed using Mozilla certificate

Related to https://github.com/influxdata/influxdb-client-python/pull/207, https://github.com/OpenAPITools/openapi-generator/pull/8108