### PR TITLE
fix(python): pass configured timeout to HTTP client

### DIFF
--- a/openapi-generator/src/main/resources/python/configuration.mustache
+++ b/openapi-generator/src/main/resources/python/configuration.mustache
@@ -98,6 +98,9 @@ class Configuration(six.with_metaclass(TypeWithDefault, object)):
         # requests to the same host, which is often the case here.
         # cpu_count * 5 is used as default value to increase performance.
         self.connection_pool_maxsize = multiprocessing.cpu_count() * 5
+        # Timeout setting for a request. If one number provided, it will be total request timeout.
+        # It can also be a pair (tuple) of (connection, read) timeouts.
+        self.timeout = None
 
         # Proxy URL
         self.proxy = None

--- a/openapi-generator/src/main/resources/python/rest.mustache
+++ b/openapi-generator/src/main/resources/python/rest.mustache
@@ -148,13 +148,14 @@ class RESTClientObject(object):
         headers = headers or {}
 
         timeout = None
-        if _request_timeout:
-            if isinstance(_request_timeout, (int, ) if six.PY3 else (int, long)):  # noqa: E501,F821
-                timeout = urllib3.Timeout(total=_request_timeout)
-            elif (isinstance(_request_timeout, tuple) and
-                  len(_request_timeout) == 2):
+        _configured_timeout = _request_timeout or self.configuration.timeout
+        if _configured_timeout:
+            if isinstance(_configured_timeout, (int, ) if six.PY3 else (int, long)):  # noqa: E501,F821
+                timeout = urllib3.Timeout(total=_configured_timeout / 1_000)
+            elif (isinstance(_configured_timeout, tuple) and
+                  len(_configured_timeout) == 2):
                 timeout = urllib3.Timeout(
-                    connect=_request_timeout[0], read=_request_timeout[1])
+                    connect=_configured_timeout[0] / 1_000, read=_configured_timeout[1] / 1_000)
 
         if 'Content-Type' not in headers:
             headers['Content-Type'] = 'application/json'


### PR DESCRIPTION
Related to https://github.com/influxdata/influxdb-client-python/issues/221

## Proposed Changes

Correctly pass configured timeout into `urllib3`.