### PR TITLE
feat(python): use InfluxDB OSS API definitions to generated APIs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ commands:
       - run:
           command: |
             mkdir -p ./build
-            git clone --single-branch --branch feat/swagger-update https://github.com/influxdata/<< parameters.client >> ./build/<< parameters.client >>
+            git clone --single-branch --branch master https://github.com/influxdata/<< parameters.client >> ./build/<< parameters.client >>
 
 jobs:
   generate-python:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,6 +53,8 @@ jobs:
   check-generated-python:
     docker:
       - image: "circleci/python:3.6-buster"
+        environment:
+          PIPENV_VENV_IN_PROJECT: true
       - image: "influxdb:latest"
         environment:
           INFLUXD_HTTP_BIND_ADDRESS: :8086
@@ -65,7 +67,9 @@ jobs:
           name: "Check Generated Client"
           command: |
             cd ./build/influxdb-client-python
-            git status
+            pip install -e . --user
+            pip install -e .\[test\] --user
+            pytest tests
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,7 @@ commands:
           command: |
             mkdir -p ./build
             git clone https://github.com/influxdata/<< parameters.client >> ./build/<< parameters.client >>
+            git checkout -B feat/swagger-update
 
 jobs:
   generate-python:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,9 +50,9 @@ jobs:
       - image: "circleci/python:3.6-buster"
     steps:
       - attach_workspace:
-          at: ./influxdb-client-python
+          at: ./
       - run:
-          name: "Generate Python client"
+          name: "Check Generated Client"
           command: |
             ls -la ./influxdb-client-python
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,7 @@ commands:
           command: |
             mkdir -p ./build
             git clone https://github.com/influxdata/<< parameters.client >> ./build/<< parameters.client >>
+            cd ./build/<< parameters.client >>
             git checkout -B feat/swagger-update
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,13 +63,25 @@ jobs:
       - influxdb-onboarding
       - attach_workspace:
           at: ./build
+      - restore_cache:
+          name: Restoring Pip Cache
+          keys:
+            - &cache-key pip-cache-v1-{{ checksum "build/influxdb-client-python/setup.py" }}
+            - pip-cache-v1
       - run:
           name: "Check Generated Client"
           command: |
             cd ./build/influxdb-client-python
             pip install -e . --user
+            pip install -e .\[extra\] --user
             pip install -e .\[test\] --user
             pytest tests
+      - save_cache:
+          name: Saving Pip Cache
+          key: *cache-key
+          paths:
+            - ".venv"
+            - "~/.cache/pip"
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,80 @@
+version: 2.1
+
+commands:
+  build-generator:
+    steps:
+      - run: mvn -f openapi-generator/pom.xml clean install -DskipTests
+  download-oss-swagger:
+    steps:
+      - run: curl https://raw.githubusercontent.com/influxdata/openapi/master/contracts/oss.yml --output ./oss.yml
+  clone-client:
+    parameters:
+      client:
+        type: string
+    steps:
+      - run:
+          command: |
+            mkdir -p ./build
+            git clone https://github.com/influxdata/<< parameters.client >> ./build/<< parameters.client >>
+
+jobs:
+  generate-python:
+    docker:
+      - image: "circleci/openjdk:8-stretch"
+    steps:
+      - checkout
+      - restore_cache:
+          name: Restoring Maven Cache
+          keys:
+            - &cache-key maven-cache_v1-{{ checksum "openapi-generator/pom.xml" }}
+            - maven-cache_v1
+      - build-generator
+      - download-oss-swagger
+      - clone-client:
+          client: influxdb-client-python
+      - run:
+          name: "Generate Python client"
+          command: |
+            ./generate-python.sh
+      - persist_to_workspace:
+          root: build
+          paths:
+            - ./influxdb-client-python
+      - save_cache:
+          name: Saving Maven Cache
+          key: *cache-key
+          paths:
+            - ~/.m2
+  check-generated-python:
+    docker:
+      - image: "circleci/python:3.6-buster"
+    steps:
+      - attach_workspace:
+          at: ./influxdb-client-python
+      - run:
+          name: "Generate Python client"
+          command: |
+            ls -la ./influxdb-client-python
+
+workflows:
+  version: 2
+  build:
+    jobs:
+      - generate-python
+      - check-generated-python:
+          requires:
+            - generate-python
+
+  nightly:
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - generate-python
+      - check-generated-python:
+          requires:
+            - generate-python

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,9 +20,7 @@ commands:
       - run:
           command: |
             mkdir -p ./build
-            git clone https://github.com/influxdata/<< parameters.client >> ./build/<< parameters.client >>
-            cd ./build/<< parameters.client >>
-            git checkout -B feat/swagger-update
+            git clone --single-branch --branch feat/swagger-update https://github.com/influxdata/<< parameters.client >> ./build/<< parameters.client >>
 
 jobs:
   generate-python:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,11 @@
 version: 2.1
 
 commands:
+  influxdb-onboarding:
+    steps:
+      - run:
+          name: "Post onBoarding request to InfluxDB 2"
+          command: ./scripts/influxdb-onboarding.sh
   build-generator:
     steps:
       - run: mvn -f openapi-generator/pom.xml clean install -DskipTests
@@ -48,13 +53,19 @@ jobs:
   check-generated-python:
     docker:
       - image: "circleci/python:3.6-buster"
+      - image: "influxdb:latest"
+        environment:
+          INFLUXD_HTTP_BIND_ADDRESS: :8086
     steps:
+      - checkout
+      - influxdb-onboarding
       - attach_workspace:
-          at: ./
+          at: ./build
       - run:
           name: "Check Generated Client"
           command: |
-            ls -la ./influxdb-client-python
+            cd ./build/influxdb-client-python
+            git status
 
 workflows:
   version: 2

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,34 @@
+---
+name: Bug report
+about: Create a report to help us improve
+---
+
+<!--
+
+Thank you for reporting a bug. 
+
+* Please add a :+1: or comment on a similar existing bug report instead of opening a new one.
+    * https://github.com/bonitoo-io/influxdb-clients-apigen/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+is%3Aclosed+sort%3Aupdated-desc+label%3Abug+
+* Please check whether the bug can be reproduced with the latest release.
+* The fastest way to fix a bug is to open a Pull Request.
+    * https://github.com/bonitoo-io/influxdb-clients-apigen/pulls
+
+-->
+
+__Steps to reproduce:__
+List the minimal actions needed to reproduce the behavior.
+
+1. ...
+2. ...
+3. ...
+
+__Expected behavior:__
+Describe what you expected to happen.
+
+__Actual behavior:__
+Describe What actually happened.
+
+__Specifications:__
+ - Client:
+ - InfluxDB Version:
+ - Platform:

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,28 @@
+---
+name: Feature request
+about: Opening a feature request kicks off a discussion
+---
+
+<!--
+
+Thank you for suggesting an idea to improve this generator. 
+
+* Please add a :+1: or comment on a similar existing feature request instead of opening a new one.
+    * https://github.com/bonitoo-io/influxdb-clients-apigen/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+is%3Aclosed+sort%3Aupdated-desc+label%3A%22enhancement%22+
+
+-->
+
+__Proposal:__
+Short summary of the feature.
+
+__Current behavior:__
+Describe what currently happens.
+
+__Desired behavior:__
+Describe what you want.
+
+__Alternatives considered:__
+Describe other solutions or features you considered.
+
+__Use case:__
+Why is this important (helps with prioritizing requests)?

--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -1,0 +1,14 @@
+Closes #
+
+## Proposed Changes
+
+_Briefly describe your proposed changes:_
+
+## Checklist
+
+<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->
+
+- [ ] CHANGELOG.md updated
+- [ ] Rebased/mergeable
+- [ ] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
+- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,0 +1,3 @@
+# docs: https://github.com/probot/semantic-pull-requests#configuration
+# Always validate the PR title AND all the commits
+titleAndCommits: true

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ build
 openapi-generator/target
 /openapi-generator/target/
 .DS_Store
+oss.yml

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ openapi-generator/target
 /openapi-generator/target/
 .DS_Store
 oss.yml
+generate-*-local.sh

--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,7 @@ pr-csharp:
 #### Python
 generate-python:
 	$(call git_checkout,influxdb-client-python)
+	@docker-compose run download-oss-swagger
 	@docker-compose run java ./generate-python.sh
 
 check-python:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Swagger code generator for InfluxDB 2.0 client libraries 
 
+[![CircleCI](https://circleci.com/gh/bonitoo-io/influxdb-clients-apigen.svg?style=svg)](https://circleci.com/gh/bonitoo-io/influxdb-clients-apigen)
+[![License](https://img.shields.io/github/license/bonitoo-io/influxdb-clients-apigen.svg)](https://github.com/bonitoo-io/influxdb-clients-apigen/blob/master/LICENSE)
+[![GitHub issues](https://img.shields.io/github/issues-raw/bonitoo-io/influxdb-clients-apigen.svg)](https://github.com/bonitoo-io/influxdb-clients-apigen/issues)
+[![GitHub pull requests](https://img.shields.io/github/issues-pr-raw/bonitoo-io/influxdb-clients-apigen.svg)](https://github.com/bonitoo-io/influxdb-clients-apigen/pulls)
+
 This repository contains tools to re-generate API from InfluxDB swagger.yml. 
 
 Supported are following client libraries: 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,11 +35,17 @@ services:
     working_dir: /code
     network_mode: host
 
-
   influxdb_v2:
     image: quay.io/influxdb/influxdb:2.0.0-beta
     ports:
       - "9999:9999"
     command: influxd --reporting-disabled
+
+  download-oss-swagger:
+    image: curlimages/curl:7.76.1
+    volumes:
+      - .:/code
+    working_dir: /code
+    command: curl https://raw.githubusercontent.com/influxdata/openapi/master/contracts/oss.yml --output /code/oss.yml
 
 

--- a/generate-python.sh
+++ b/generate-python.sh
@@ -7,4 +7,4 @@ SCRIPT_PATH="$( cd "$(dirname "$0")" ; pwd -P )"
 rm ./build/influxdb-client-python/influxdb_client/domain/*.py || true
 rm ./build/influxdb-client-python/influxdb_client/service/*.py || true
 
-mvn -f ./openapi-generator/pom-python.xml -DclientVersion=1.11.0dev -DswaggerLocation=./swagger.yml org.openapitools:openapi-generator-maven-plugin:generate
+mvn -f ./openapi-generator/pom-python.xml -DclientVersion=1.11.0dev -DswaggerLocation="${SCRIPT_PATH}/oss.yml" org.openapitools:openapi-generator-maven-plugin:generate

--- a/openapi-generator/pom-python.xml
+++ b/openapi-generator/pom-python.xml
@@ -10,7 +10,8 @@
         <library>urllib3</library>
         <swaggerLocation>${project.basedir}/../swagger.yml</swaggerLocation>
         <clientVersion>1.11.0dev</clientVersion>
-    </properties>
+		<outputLocation>${project.basedir}/../build/influxdb-client-python</outputLocation>
+	</properties>
     <build>
         <plugins>
             <plugin>
@@ -35,7 +36,7 @@
                     <generateSupportingFiles>true</generateSupportingFiles>
                     <generateModelTests>false</generateModelTests>
                     <verbose>false</verbose>
-                    <output>${project.basedir}/../build/influxdb-client-python</output>
+                    <output>${outputLocation}</output>
                     <addCompileSourceRoot>false</addCompileSourceRoot>
                     <library>${library}</library>
                 </configuration>

--- a/openapi-generator/pom-python.xml
+++ b/openapi-generator/pom-python.xml
@@ -8,7 +8,7 @@
     <name>influxdb-client-python</name>
     <properties>
         <library>urllib3</library>
-        <swaggerLocation>${project.basedir}/../swagger.yml</swaggerLocation>
+        <swaggerLocation>${project.basedir}/../oss.yml</swaggerLocation>
         <clientVersion>1.11.0dev</clientVersion>
 		<outputLocation>${project.basedir}/../build/influxdb-client-python</outputLocation>
 	</properties>

--- a/openapi-generator/pom.xml
+++ b/openapi-generator/pom.xml
@@ -147,7 +147,12 @@
             <version>${openapi-generator-version}</version>
             <scope>provided</scope>
         </dependency>
-    </dependencies>
+		<dependency>
+			<groupId>org.jetbrains</groupId>
+			<artifactId>annotations</artifactId>
+			<version>20.1.0</version>
+		</dependency>
+	</dependencies>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <openapi-generator-version>3.3.4</openapi-generator-version>

--- a/openapi-generator/src/main/java/com/influxdb/codegen/InfluxPythonGenerator.java
+++ b/openapi-generator/src/main/java/com/influxdb/codegen/InfluxPythonGenerator.java
@@ -1,18 +1,13 @@
 package com.influxdb.codegen;
 
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import javax.annotation.Nonnull;
-
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.media.Schema;
-import org.openapitools.codegen.CodegenModel;
 import org.openapitools.codegen.CodegenOperation;
 import org.openapitools.codegen.languages.PythonClientCodegen;
 
@@ -179,26 +174,21 @@ public class InfluxPythonGenerator extends PythonClientCodegen {
     public Map<String, Object> postProcessAllModels(final Map<String, Object> models) {
 
         Map<String, Object> allModels = super.postProcessAllModels(models);
+		postProcessHelper.postProcessModels(allModels);
 
-        for (Map.Entry<String, Object> entry : allModels.entrySet()) {
-
-            String modelName = entry.getKey();
-            Object modelConfig = entry.getValue();
-
-            CodegenModel model = getModel((HashMap) modelConfig);
-
-            if (model.getParent() != null) {
-                CodegenModel parentModel = getModel((HashMap) allModels.get(model.getParent()));
-                model.vendorExtensions.put("x-parent-classFilename", parentModel.getClassFilename());
-                model.vendorExtensions.put("x-has-parent-vars", !parentModel.getVars().isEmpty());
-                model.vendorExtensions.put("x-parent-vars", parentModel.getVars());
-            }
-        }
-
-        return allModels;
+		return allModels;
     }
 
-    @Override
+	@Override
+	public String escapeText(String input) {
+		if (input == null) {
+			return null;
+		}
+
+		return super.escapeText(input).replace("\\\"", "\"");
+	}
+
+	@Override
     public String toApiName(String name) {
         if (name.length() == 0) {
             return "DefaultService";

--- a/openapi-generator/src/main/java/com/influxdb/codegen/InfluxPythonGenerator.java
+++ b/openapi-generator/src/main/java/com/influxdb/codegen/InfluxPythonGenerator.java
@@ -10,11 +10,11 @@ import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.media.Schema;
 import org.openapitools.codegen.CodegenOperation;
 import org.openapitools.codegen.languages.PythonClientCodegen;
-
-import static org.openapitools.codegen.utils.StringUtils.camelize;
-import static org.openapitools.codegen.utils.StringUtils.underscore;
+import org.openapitools.codegen.utils.StringUtils;
 
 public class InfluxPythonGenerator extends PythonClientCodegen {
+
+	private PostProcessHelper postProcessHelper;
 
     public InfluxPythonGenerator() {
         apiPackage = "service";
@@ -41,35 +41,20 @@ public class InfluxPythonGenerator extends PythonClientCodegen {
         return "Generates a influx-python client library.";
     }
 
-    @Override
-    public String escapeText(String input) {
-        if (input == null) {
-            return input;
-        }
+	@Override
+	public void setGlobalOpenAPI(final OpenAPI openAPI)
+	{
+		postProcessHelper = new PostProcessHelper(openAPI);
+		postProcessHelper.postProcessOpenAPI();
 
-        return super.escapeText(input).replace("\\\"", "\"");
-    }
+		super.setGlobalOpenAPI(openAPI);
+	}
 
 	@Override
 	public CodegenOperation fromOperation(String path, String httpMethod, Operation operation, Map<String, Schema> definitions, OpenAPI openAPI) {
 
 		CodegenOperation op = super.fromOperation(path, httpMethod, operation, definitions, openAPI);
-
-		//
-		// Set base path
-		//
-		String url;
-		if (operation.getServers() != null) {
-			url = operation.getServers().get(0).getUrl();
-		} else if (openAPI.getPaths().get(path).getServers() != null) {
-			url = openAPI.getPaths().get(path).getServers().get(0).getUrl();
-		} else {
-			url = openAPI.getServers().get(0).getUrl();
-		}
-
-		if (!url.equals("/")) {
-			op.path = url + op.path;
-		}
+		postProcessHelper.postProcessOperation(path, operation, op);
 
 		return op;
 	}
@@ -90,84 +75,6 @@ public class InfluxPythonGenerator extends PythonClientCodegen {
         supportingFiles = supportingFiles.stream()
                 .filter(supportingFile -> !useless.contains(supportingFile.destinationFilename))
                 .collect(Collectors.toList());
-    }
-
-    @Override
-    public CodegenModel fromModel(final String name, final Schema model, final Map<String, Schema> allDefinitions) {
-        CodegenModel codegenModel = super.fromModel(name, model, allDefinitions);
-
-        if (name.endsWith("ViewProperties") && !name.equals("ViewProperties"))
-        {
-            codegenModel.setParent("ViewProperties");
-            codegenModel.setParentSchema("ViewProperties");
-        }
-
-        if (allDefinitions.containsKey(name + "Base")) {
-            codegenModel.setParent(name + "Base");
-            codegenModel.setParentSchema(name + "Base");
-        }
-
-        if (name.equals("ViewProperties"))  {
-            codegenModel.setReadWriteVars(new ArrayList<>());
-            codegenModel.setRequiredVars(new ArrayList<>());
-            codegenModel.hasOnlyReadOnly = true;
-            codegenModel.hasRequired = false;
-        }
-
-		if (codegenModel.name.equals("LesserThreshold") || codegenModel.name.equals("GreaterThreshold")
-				|| codegenModel.name.equals("RangeThreshold")) {
-			codegenModel.setParent("Threshold");
-			codegenModel.setParentSchema("Threshold");
-		}
-
-		if (codegenModel.name.equals("CheckBase")) {
-			codegenModel.setParent("CheckDiscriminator");
-			codegenModel.setParentSchema("CheckDiscriminator");
-		}
-
-		if (codegenModel.name.equals("CheckDiscriminator")) {
-			codegenModel.setParent("PostCheck");
-			codegenModel.setParentSchema("PostCheck");
-		}
-
-		if (codegenModel.name.equals("NotificationEndpointBase")) {
-			codegenModel.setParent("NotificationEndpointDiscriminator");
-			codegenModel.setParentSchema("NotificationEndpointDiscriminator");
-		}
-
-		if (codegenModel.name.equals("PostCheck") || codegenModel.name.equals("PostNotificationEndpoint")) {
-			codegenModel.setParent(null);
-			codegenModel.setParentSchema(null);
-		}
-
-		if (codegenModel.name.equals("DeadmanCheck") || codegenModel.name.equals("ThresholdCheck")) {
-			codegenModel.setParent("Check");
-			codegenModel.setParentSchema("Check");
-		}
-
-		if (codegenModel.name.equals("SlackNotificationEndpoint") || codegenModel.name.equals("PagerDutyNotificationEndpoint")
-				|| codegenModel.name.equals("HTTPNotificationEndpoint")) {
-			codegenModel.setParent("NotificationEndpoint");
-			codegenModel.setParentSchema("NotificationEndpoint");
-		}
-
-		if (codegenModel.name.equals("NotificationEndpointDiscriminator")) {
-			codegenModel.setParent("PostNotificationEndpoint");
-			codegenModel.setParentSchema("PostNotificationEndpoint");
-		}
-
-		if (codegenModel.name.equals("NotificationRuleBase")) {
-			codegenModel.setParent("PostNotificationRule");
-			codegenModel.setParentSchema("PostNotificationRule");
-		}
-
-		if (codegenModel.name.endsWith("Discriminator")) {
-			codegenModel.hasOnlyReadOnly = true;
-			codegenModel.hasRequired = false;
-			codegenModel.readWriteVars.clear();
-		}
-
-        return codegenModel;
     }
 
     @Override
@@ -194,7 +101,7 @@ public class InfluxPythonGenerator extends PythonClientCodegen {
             return "DefaultService";
         }
         // e.g. phone_number_service => PhoneNumberService
-        return camelize(name) + "Service";
+        return StringUtils.camelize(name) + "Service";
     }
 
     @Override
@@ -203,7 +110,7 @@ public class InfluxPythonGenerator extends PythonClientCodegen {
         if (name.length() == 0) {
             return "default_service";
         }
-        return underscore(name) + "_service";
+        return StringUtils.underscore(name) + "_service";
     }
 
     @Override
@@ -212,24 +119,19 @@ public class InfluxPythonGenerator extends PythonClientCodegen {
         name = name.replaceAll("-", "_");
 
         // e.g. PhoneNumberService.py => phone_number_service.py
-        return underscore(name) + "_service";
+        return StringUtils.underscore(name) + "_service";
     }
 
 	@Override
 	public String toModelName(final String name) {
 		final String modelName = super.toModelName(name);
-		if ("PostBucketRequestRetentionRules".equals(modelName)) {
+		if ("RetentionRule".equals(modelName)) {
 			return "BucketRetentionRules";
+		}
+		if ("Resource".equals(modelName)) {
+			return "PermissionResource";
 		}
 
 		return modelName;
 	}
-
-    @Nonnull
-    private CodegenModel getModel(@Nonnull final HashMap modelConfig) {
-
-        HashMap models = (HashMap) ((ArrayList) modelConfig.get("models")).get(0);
-
-        return (CodegenModel) models.get("model");
-    }
 }

--- a/openapi-generator/src/main/java/com/influxdb/codegen/PostProcessHelper.java
+++ b/openapi-generator/src/main/java/com/influxdb/codegen/PostProcessHelper.java
@@ -83,14 +83,6 @@ class PostProcessHelper
 		}
 
 		//
-		// Fix required parameters
-		//
-		{
-			Schema schema = openAPI.getComponents().getSchemas().get("NotificationRuleBase");
-			schema.getRequired().removeAll(Arrays.asList("tagRules"));
-		}
-
-		//
 		// Drop empty body
 		//
 		{

--- a/openapi-generator/src/main/java/com/influxdb/codegen/PostProcessHelper.java
+++ b/openapi-generator/src/main/java/com/influxdb/codegen/PostProcessHelper.java
@@ -1,0 +1,78 @@
+package com.influxdb.codegen;
+
+import javax.annotation.Nonnull;
+
+import java.util.Map;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.media.ComposedSchema;
+import io.swagger.v3.oas.models.media.DateTimeSchema;
+import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.media.ObjectSchema;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.parameters.RequestBody;
+import org.openapitools.codegen.CodegenOperation;
+
+/**
+ * @author Jakub Bednar (18/05/2021 13:20)
+ */
+class PostProcessHelper
+{
+	private final OpenAPI openAPI;
+
+	public PostProcessHelper(final OpenAPI openAPI)
+	{
+		this.openAPI = openAPI;
+	}
+
+	void postProcessOpenAPI()
+	{
+		//
+		// Drop supports for InfluxQL
+		//
+		{
+			RequestBody requestBody = openAPI.getPaths().get("/query").getPost().getRequestBody();
+			MediaType mediaType = requestBody.getContent().get("application/json");
+			// Set correct schema to `Query` object
+			Schema schema = ((ComposedSchema) mediaType.getSchema()).getOneOf().get(0);
+			mediaType.schema(schema);
+		}
+
+		//
+		// Set DateTimeSchema for DateTimeLiteral
+		//
+		{
+			ObjectSchema objectSchema = (ObjectSchema) openAPI.getComponents().getSchemas().get("DateTimeLiteral");
+			Map<String, Schema> properties = objectSchema.getProperties();
+			Schema dateTimeSchema = new DateTimeSchema()
+					.type("string")
+					.format("date-time")
+					.description(properties.get("value").getDescription());
+			properties.put("value", dateTimeSchema);
+		}
+	}
+
+	void postProcessOperation(String path, Operation operation, CodegenOperation op)
+	{
+		//
+		// Set correct path for /health, /ready, /setup ...
+		//
+		String url;
+		if (operation.getServers() != null) {
+			url = operation.getServers().get(0).getUrl();
+		} else if (openAPI.getPaths().get(path).getServers() != null) {
+			url = openAPI.getPaths().get(path).getServers().get(0).getUrl();
+		} else {
+			url = openAPI.getServers().get(0).getUrl();
+		}
+
+		if (url != null) {
+			url = url.replaceAll("https://raw.githubusercontent.com", "");
+		}
+
+		if (!"/".equals(url) && url != null) {
+			op.path = url + op.path;
+		}
+	}
+}

--- a/openapi-generator/src/main/java/com/influxdb/codegen/PostProcessHelper.java
+++ b/openapi-generator/src/main/java/com/influxdb/codegen/PostProcessHelper.java
@@ -125,9 +125,6 @@ class PostProcessHelper
 			//
 			if (model.getParent() != null) {
 				CodegenModel parentModel = getModel((HashMap) allModels.get(model.getParent()));
-//				model.vendorExtensions.put("x-parent-classFilename", parentModel.getClassFilename());
-//				model.vendorExtensions.put("x-has-parent-vars", !parentModel.getVars().isEmpty());
-//				model.vendorExtensions.put("x-parent-vars", parentModel.getVars());
 				setParentVars(model, parentModel, parentModel.getVars());
 			}
 		}

--- a/openapi-generator/src/main/java/com/influxdb/codegen/PostProcessHelper.java
+++ b/openapi-generator/src/main/java/com/influxdb/codegen/PostProcessHelper.java
@@ -2,23 +2,22 @@ package com.influxdb.codegen;
 
 import javax.annotation.Nonnull;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
-import java.util.function.BiConsumer;
-import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.PathItem;
-import io.swagger.v3.oas.models.Paths;
 import io.swagger.v3.oas.models.media.ComposedSchema;
-import io.swagger.v3.oas.models.media.Content;
-import io.swagger.v3.oas.models.media.DateTimeSchema;
 import io.swagger.v3.oas.models.media.MediaType;
 import io.swagger.v3.oas.models.media.ObjectSchema;
 import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.parameters.RequestBody;
 import org.intellij.lang.annotations.Language;
+import org.openapitools.codegen.CodegenDiscriminator;
 import org.openapitools.codegen.CodegenModel;
 import org.openapitools.codegen.CodegenOperation;
 import org.openapitools.codegen.utils.StringUtils;
@@ -50,13 +49,11 @@ class PostProcessHelper
 		}
 
 		//
-		// Set DateTimeSchema for DateTimeLiteral
+		// Set correct name for NotificationEndpointDiscrimator
 		//
 		{
-			Schema dateTimeSchema = new DateTimeSchema()
-					.type("string")
-					.format("date-time");
-			changePropertySchema("value", "DateTimeLiteral", dateTimeSchema);
+			Schema schema = openAPI.getComponents().getSchemas().remove("NotificationEndpointDiscrimator");
+			openAPI.getComponents().getSchemas().put("NotificationEndpointDiscriminator", schema);
 		}
 
 		//
@@ -89,25 +86,20 @@ class PostProcessHelper
 		// Set correct name for Inline Request Body
 		//
 		for (PathItem pathItem: openAPI.getPaths().values()) {
-			pathItem.readOperationsMap().forEach(new BiConsumer<PathItem.HttpMethod, Operation>()
-			{
-				@Override
-				public void accept(final PathItem.HttpMethod method, final Operation operation)
-				{
-					// find only operation with body
-					if (operation.getRequestBody() == null || operation.getRequestBody().getContent() == null) {
-						return;
-					}
+			pathItem.readOperationsMap().forEach((method, operation) -> {
+				// find only operation with body
+				if (operation.getRequestBody() == null || operation.getRequestBody().getContent() == null) {
+					return;
+				}
 
-					for (MediaType mediaType: operation.getRequestBody().getContent().values()) {
-						Schema schema = mediaType.getSchema();
-						// find only body with InlineObject and without Title
-						if (schema instanceof ObjectSchema && schema.get$ref() == null && schema.getTitle() == null)
-						{
-							// set name from operationId: "PatchDashboardsID" => "PatchPatchDashboardsIDRequest"
-							String title = method.name() + " " + operation.getSummary() + " " + "Request";
-							schema.title(StringUtils.camelize(StringUtils.underscore(title)));
-						}
+				for (MediaType mediaType: operation.getRequestBody().getContent().values()) {
+					Schema schema = mediaType.getSchema();
+					// find only body with InlineObject and without Title
+					if (schema instanceof ObjectSchema && schema.get$ref() == null && schema.getTitle() == null)
+					{
+						// set name from operationId: "PatchDashboardsID" => "PatchPatchDashboardsIDRequest"
+						String title = method.name() + " " + operation.getSummary() + " " + "Request";
+						schema.title(StringUtils.camelize(StringUtils.underscore(title)));
 					}
 				}
 			});
@@ -116,29 +108,50 @@ class PostProcessHelper
 
 	void postProcessModels(Map<String, Object> allModels) {
 
-		// Iterate all models
 		for (Map.Entry<String, Object> entry : allModels.entrySet())
 		{
-			CodegenModel pluginModel = getModel((HashMap) entry.getValue());
+			CodegenModel model = getModel((HashMap) entry.getValue());
 
 			//
 			// Set correct inheritance. The "interfaces" extends base object.
 			//
-			if (!pluginModel.hasVars && pluginModel.interfaceModels != null)
+			if (!model.hasVars && model.interfaceModels != null)
 			{
-				if (pluginModel.getName().matches("(.*)Check(.*)|(.*)Notification(.*)")) {
+				if (model.getName().matches("(.*)Check(.*)|(.*)Notification(.*)")) {
 					continue;
 				}
 
-				for (CodegenModel interfaceModel : pluginModel.interfaceModels)
+				for (CodegenModel interfaceModel : model.interfaceModels)
 				{
-					interfaceModel.setParent(pluginModel.classname);
+					interfaceModel.setParent(model.classname);
 				}
 
-				pluginModel.interfaces.clear();
-				pluginModel.interfaceModels.clear();
+				model.interfaces.clear();
+				model.interfaceModels.clear();
 			}
 		}
+
+		fixInheritance("Check", Arrays.asList("Deadman", "Custom", "Threshold"), allModels);
+		fixInheritance("Threshold", Arrays.asList("Greater", "Lesser", "Range"), allModels);
+		fixInheritance("NotificationEndpoint", Arrays.asList("Slack", "PagerDuty", "HTTP", "Telegram"), allModels);
+		fixInheritance("NotificationRule", Arrays.asList("Slack", "PagerDuty", "SMTP", "HTTP", "Telegram"), allModels);
+
+		// Iterate all models
+		for (Map.Entry<String, Object> entry : allModels.entrySet())
+		{
+			CodegenModel model = getModel((HashMap) entry.getValue());
+
+			//
+			// Set parent vars extension => useful for Object initialization
+			//
+			if (model.getParent() != null) {
+				CodegenModel parentModel = getModel((HashMap) allModels.get(model.getParent()));
+				model.vendorExtensions.put("x-parent-classFilename", parentModel.getClassFilename());
+				model.vendorExtensions.put("x-has-parent-vars", !parentModel.getVars().isEmpty());
+				model.vendorExtensions.put("x-parent-vars", parentModel.getVars());
+			}
+		}
+
 	}
 
 	void postProcessOperation(String path, Operation operation, CodegenOperation op)
@@ -193,5 +206,79 @@ class PostProcessHelper
 		openAPI.getPaths()
 				.entrySet()
 				.removeIf(entry -> entry.getKey().matches(regex));
+	}
+
+	private void fixInheritance(final String name, final List<String> mappings, final Map<String, Object> allModels)
+	{
+		CodegenModel schema = getModel((HashMap) allModels.get(name));
+		CodegenModel base = getModel((HashMap) allModels.get(name + "Base"));
+		CodegenModel discriminator = schema;
+		// Try to find intermediate entity -> Check -> CheckDiscriminator -> CheckBase
+		if (allModels.containsKey(name + "Discriminator"))
+		{
+			discriminator = getModel((HashMap) allModels.get(name + "Discriminator"));
+		}
+
+		discriminator.setChildren(new ArrayList<>());
+		discriminator.hasChildren = false;
+		discriminator.setParentModel(base);
+		discriminator.setParent(base.getName());
+		discriminator.setParentSchema(base.getName());
+		discriminator.setParentVars(base.getVars());
+
+		List<CodegenModel> discriminatorModels = mappings.stream()
+				.map(mapping -> getModel((HashMap) allModels.get(mapping + name)))
+				.collect(Collectors.toList());
+
+		for (CodegenModel discriminatorModel : discriminatorModels)
+		{
+			CodegenModel discriminatorModelBase = discriminatorModel;
+			// if there is BaseModel then extend this SlackNotificationRule > SlackNotificationRuleBase
+			if (allModels.containsKey(discriminatorModel.name + "Base")) {
+				discriminatorModelBase = getModel((HashMap) allModels.get(discriminatorModel.name + "Base"));
+				discriminatorModel.setParentModel(discriminatorModelBase);
+				discriminatorModel.setParent(discriminatorModelBase.getName());
+				discriminatorModel.setParentSchema(discriminatorModelBase.getName());
+				discriminatorModel.vendorExtensions.put("x-has-parent-vars", !base.getVars().isEmpty());
+				discriminatorModel.vendorExtensions.put("x-parent-vars", base.getVars());
+			}
+
+			discriminatorModelBase.setParentModel(discriminator);
+			discriminatorModelBase.setParent(discriminator.getName());
+			discriminatorModelBase.setParentSchema(discriminator.getName());
+			discriminatorModelBase.vendorExtensions.put("x-has-parent-vars", !base.getVars().isEmpty());
+			discriminatorModelBase.vendorExtensions.put("x-parent-vars", base.getVars());
+
+			// set correct name for discriminator
+			String discriminatorKey = discriminator.getDiscriminator().getMappedModels()
+					.stream()
+					.filter(mapped -> discriminatorModel.name.equals(mapped.getModelName()))
+					.findFirst()
+					.map(CodegenDiscriminator.MappedModel::getMappingName)
+					.get();
+
+			discriminatorModel.vendorExtensions.put("x-discriminator-value", discriminatorKey);
+		}
+
+		// If there is also Post schema then use same discriminator: Check, PostCheck
+		List<CodegenModel> rootModels = new ArrayList<>();
+		rootModels.add(schema);
+		if (allModels.containsKey("Post" + name))
+		{
+			rootModels.add(getModel((HashMap) allModels.get("Post" + name)));
+		}
+
+		for (CodegenModel rootModel : rootModels)
+		{
+			rootModel.setDiscriminator(discriminator.getDiscriminator());
+			rootModel.setChildren(discriminatorModels);
+			rootModel.hasChildren = true;
+
+			// If there is no intermediate entity, than leave current parent schema
+			if (allModels.containsKey(name + "Discriminator")) {
+				rootModel.setParentSchema(null);
+				rootModel.setParent(null);
+			}
+		}
 	}
 }

--- a/openapi-generator/src/main/java/com/influxdb/codegen/PostProcessHelper.java
+++ b/openapi-generator/src/main/java/com/influxdb/codegen/PostProcessHelper.java
@@ -16,6 +16,7 @@ import io.swagger.v3.oas.models.media.ComposedSchema;
 import io.swagger.v3.oas.models.media.MediaType;
 import io.swagger.v3.oas.models.media.ObjectSchema;
 import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.media.StringSchema;
 import io.swagger.v3.oas.models.parameters.RequestBody;
 import org.intellij.lang.annotations.Language;
 import org.openapitools.codegen.CodegenDiscriminator;
@@ -47,6 +48,14 @@ class PostProcessHelper
 			Schema schema = ((ComposedSchema) mediaType.getSchema()).getOneOf().get(0);
 			mediaType.schema(schema);
 			dropSchemas("InfluxQLQuery");
+		}
+
+		//
+		// Use Generic schema for Query parameters
+		//
+		{
+			Schema newPropertySchema = new ObjectSchema().additionalProperties(new ObjectSchema());
+			changePropertySchema("params", "Query", newPropertySchema);
 		}
 
 		//
@@ -83,11 +92,16 @@ class PostProcessHelper
 		}
 
 		//
-		// Drop empty body
+		// Change type of generic Object to String
+		//
+		// see: https://github.com/influxdata/openapi/pull/90
 		//
 		{
 			PathItem pathItem = openAPI.getPaths().get("/tasks/{taskID}/runs/{runID}/retry");
-			pathItem.getPost().requestBody(null);
+			pathItem.getPost()
+					.getRequestBody()
+					.getContent()
+					.values().forEach(mediaType -> mediaType.setSchema(new StringSchema()));
 		}
 
 		//

--- a/openapi-generator/src/main/resources/python/configuration.mustache
+++ b/openapi-generator/src/main/resources/python/configuration.mustache
@@ -98,6 +98,9 @@ class Configuration(six.with_metaclass(TypeWithDefault, object)):
         # requests to the same host, which is often the case here.
         # cpu_count * 5 is used as default value to increase performance.
         self.connection_pool_maxsize = multiprocessing.cpu_count() * 5
+        # Timeout setting for a request. If one number provided, it will be total request timeout.
+        # It can also be a pair (tuple) of (connection, read) timeouts.
+        self.timeout = None
 
         # Proxy URL
         self.proxy = None

--- a/openapi-generator/src/main/resources/python/rest.mustache
+++ b/openapi-generator/src/main/resources/python/rest.mustache
@@ -148,13 +148,14 @@ class RESTClientObject(object):
         headers = headers or {}
 
         timeout = None
-        if _request_timeout:
-            if isinstance(_request_timeout, (int, ) if six.PY3 else (int, long)):  # noqa: E501,F821
-                timeout = urllib3.Timeout(total=_request_timeout)
-            elif (isinstance(_request_timeout, tuple) and
-                  len(_request_timeout) == 2):
+        _configured_timeout = _request_timeout or self.configuration.timeout
+        if _configured_timeout:
+            if isinstance(_configured_timeout, (int, ) if six.PY3 else (int, long)):  # noqa: E501,F821
+                timeout = urllib3.Timeout(total=_configured_timeout / 1_000)
+            elif (isinstance(_configured_timeout, tuple) and
+                  len(_configured_timeout) == 2):
                 timeout = urllib3.Timeout(
-                    connect=_request_timeout[0], read=_request_timeout[1])
+                    connect=_configured_timeout[0] / 1_000, read=_configured_timeout[1] / 1_000)
 
         if 'Content-Type' not in headers:
             headers['Content-Type'] = 'application/json'

--- a/scripts/influxdb-onboarding.sh
+++ b/scripts/influxdb-onboarding.sh
@@ -2,12 +2,12 @@
 set -e
 
 echo "Wait to start InfluxDB 2.0"
-wget -S --spider --tries=20 --retry-connrefused --waitretry=5 http://localhost:9999/metrics
+wget -S --spider --tries=20 --retry-connrefused --waitretry=5 http://localhost:8086/metrics
 
 echo
 echo "Post onBoarding request, to setup initial user (my-user@my-password), org (my-org) and bucketSetup (my-bucket)"
 echo
-curl -i -X POST http://localhost:9999/api/v2/setup -H 'accept: application/json' \
+curl -i -X POST http://localhost:8086/api/v2/setup -H 'accept: application/json' \
     -d '{
             "username": "my-user",
             "password": "my-password",


### PR DESCRIPTION
Related to https://github.com/influxdata/influxdb-client-python/pull/261

## Proposed Changes

- use InfluxDB OSS API definitions to generated APIs
- add CircleCI build to check generated client - currently only `python`
  ![image](https://user-images.githubusercontent.com/455137/119492512-73f65b80-bd5f-11eb-8b52-a14a6938dbe7.png)


The build will be past after merge https://github.com/influxdata/influxdb-client-python/pull/261.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] Rebased/mergeable
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
