### PR TITLE
chore(python): version of client is specified on one place

### DIFF
--- a/generate-python.sh
+++ b/generate-python.sh
@@ -7,4 +7,4 @@ SCRIPT_PATH="$( cd "$(dirname "$0")" ; pwd -P )"
 rm ./build/influxdb-client-python/influxdb_client/domain/*.py || true
 rm ./build/influxdb-client-python/influxdb_client/service/*.py || true
 
-mvn -f ./openapi-generator/pom-python.xml -DclientVersion=1.11.0dev -DswaggerLocation="${SCRIPT_PATH}/oss.yml" org.openapitools:openapi-generator-maven-plugin:generate
+mvn -f ./openapi-generator/pom-python.xml -DswaggerLocation="${SCRIPT_PATH}/oss.yml" org.openapitools:openapi-generator-maven-plugin:generate

--- a/openapi-generator/pom-python.xml
+++ b/openapi-generator/pom-python.xml
@@ -9,7 +9,6 @@
     <properties>
         <library>urllib3</library>
         <swaggerLocation>${project.basedir}/../oss.yml</swaggerLocation>
-        <clientVersion>1.11.0dev</clientVersion>
 		<outputLocation>${project.basedir}/../build/influxdb-client-python</outputLocation>
 	</properties>
     <build>
@@ -27,7 +26,6 @@
                         <packageName>influxdb_client</packageName>
                         <sourceFolder>/</sourceFolder>
                         <validatable>false</validatable>
-                        <packageVersion>${clientVersion}</packageVersion>
                     </configOptions>
                     <generateModelDocumentation>false</generateModelDocumentation>
                     <generateApiDocumentation>false</generateApiDocumentation>

--- a/openapi-generator/src/main/resources/python/__init__package.mustache
+++ b/openapi-generator/src/main/resources/python/__init__package.mustache
@@ -27,4 +27,6 @@ from influxdb_client.client.write_api import WriteApi, WriteOptions
 from influxdb_client.client.influxdb_client import InfluxDBClient
 from influxdb_client.client.write.point import Point
 
-__version__ = '{{packageVersion}}'
+from influxdb_client.version import CLIENT_VERSION
+
+__version__ = CLIENT_VERSION

--- a/openapi-generator/src/main/resources/python/api_client.mustache
+++ b/openapi-generator/src/main/resources/python/api_client.mustache
@@ -71,7 +71,8 @@ class ApiClient(object):
             self.default_headers[header_name] = header_value
         self.cookie = cookie
         # Set default User-Agent.
-        self.user_agent = 'influxdb-client-python/{{{packageVersion}}}'
+        from influxdb_client import CLIENT_VERSION
+        self.user_agent = f'influxdb-client-python/{CLIENT_VERSION}'
 
     def __del__(self):
         """Dispose pools."""

--- a/openapi-generator/src/main/resources/python/configuration.mustache
+++ b/openapi-generator/src/main/resources/python/configuration.mustache
@@ -256,12 +256,13 @@ class Configuration(six.with_metaclass(TypeWithDefault, object)):
 
         :return: The report for debugging.
         """
+        from influxdb_client import CLIENT_VERSION
         return "Python SDK Debug Report:\n"\
                "OS: {env}\n"\
                "Python Version: {pyversion}\n"\
                "Version of the API: {{version}}\n"\
-               "SDK Package Version: {{packageVersion}}".\
-               format(env=sys.platform, pyversion=sys.version)
+               "SDK Package Version: {client_version}".\
+               format(env=sys.platform, pyversion=sys.version, client_version=CLIENT_VERSION)
 
     def update_request_header_params(self, path: str, params: dict):
         """Update header params based on custom settings.


### PR DESCRIPTION
Related to https://github.com/influxdata/influxdb-client-python/pull/265

## Proposed Changes

The version of client is specified on one place - useful for simple release and update management.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] Rebased/mergeable
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
