### PR TITLE
feat(java): adapters are static to avoid dependency to `jdk.unsupported` in constructions by reflection

### DIFF
--- a/openapi-generator/src/main/resources/Java/pojo.mustache
+++ b/openapi-generator/src/main/resources/Java/pojo.mustache
@@ -310,7 +310,7 @@ public class {{classname}}{{#vendorExtensions.x-has-generic-type}}{{{vendorExten
   };
 {{/parcelableModel}}
 {{#vendorExtensions.x-type-adapters.entrySet}}
-  public class {{value.classname}} implements JsonDeserializer<Object>, JsonSerializer<Object> {
+  public static class {{value.classname}} implements JsonDeserializer<Object>, JsonSerializer<Object> {
 
     public {{value.classname}}() {
     }


### PR DESCRIPTION
Releated to https://github.com/influxdata/influxdb-client-java/pull/258

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] Rebased/mergeable
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
