### PR TITLE
fix(python, php): compatibility with new swagger version

### DIFF
--- a/openapi-generator/src/main/java/com/influxdb/codegen/InfluxCSharpGenerator.java
+++ b/openapi-generator/src/main/java/com/influxdb/codegen/InfluxCSharpGenerator.java
@@ -209,6 +209,12 @@ public class InfluxCSharpGenerator extends CSharpClientCodegen implements Influx
 		return true;
 	}
 
+	@Override
+	public boolean usesOwnAuthorizationSchema()
+	{
+		return false;
+	}
+
 	@NotNull
 	@Override
 	public Collection<String> getTypeAdapterImports()

--- a/openapi-generator/src/main/java/com/influxdb/codegen/InfluxGenerator.java
+++ b/openapi-generator/src/main/java/com/influxdb/codegen/InfluxGenerator.java
@@ -24,6 +24,8 @@ public interface InfluxGenerator
 
 	boolean compileTimeInheritance();
 
+	boolean usesOwnAuthorizationSchema();
+
 	@Nonnull
 	Collection<String> getTypeAdapterImports();
 }

--- a/openapi-generator/src/main/java/com/influxdb/codegen/InfluxJavaGenerator.java
+++ b/openapi-generator/src/main/java/com/influxdb/codegen/InfluxJavaGenerator.java
@@ -430,6 +430,12 @@ public class InfluxJavaGenerator extends JavaClientCodegen implements InfluxGene
 		return true;
 	}
 
+	@Override
+	public boolean usesOwnAuthorizationSchema()
+	{
+		return false;
+	}
+
 	@NotNull
 	@Override
 	public Collection<String> getTypeAdapterImports()

--- a/openapi-generator/src/main/java/com/influxdb/codegen/InfluxPhpGenerator.java
+++ b/openapi-generator/src/main/java/com/influxdb/codegen/InfluxPhpGenerator.java
@@ -197,6 +197,12 @@ public class InfluxPhpGenerator extends PhpClientCodegen implements InfluxGenera
 		return true;
 	}
 
+	@Override
+	public boolean usesOwnAuthorizationSchema()
+	{
+		return false;
+	}
+
 	@NotNull
 	@Override
 	public Collection<String> getTypeAdapterImports()

--- a/openapi-generator/src/main/java/com/influxdb/codegen/InfluxPhpGenerator.java
+++ b/openapi-generator/src/main/java/com/influxdb/codegen/InfluxPhpGenerator.java
@@ -200,7 +200,7 @@ public class InfluxPhpGenerator extends PhpClientCodegen implements InfluxGenera
 	@Override
 	public boolean usesOwnAuthorizationSchema()
 	{
-		return false;
+		return true;
 	}
 
 	@NotNull

--- a/openapi-generator/src/main/java/com/influxdb/codegen/InfluxPythonGenerator.java
+++ b/openapi-generator/src/main/java/com/influxdb/codegen/InfluxPythonGenerator.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import com.google.common.collect.Lists;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.media.Schema;
@@ -127,6 +128,17 @@ public class InfluxPythonGenerator extends PythonClientCodegen implements Influx
     }
 
 	@Override
+	public void processOpenAPI(OpenAPI openAPI) {
+
+		List<String> serviceInits = Lists.newArrayList(
+				"influxdb_client/client/write/__init__.py",
+				"influxdb_client/client/__init__.py",
+				"tests/__init__.py");
+		
+		postProcessHelper.copyFiles("influxdb_client/service/__init__.py", serviceInits, this);
+	}
+
+	@Override
 	public String toModelName(final String name) {
 		final String modelName = super.toModelName(name);
 		if ("RetentionRule".equals(modelName)) {
@@ -163,6 +175,12 @@ public class InfluxPythonGenerator extends PythonClientCodegen implements Influx
 	public boolean compileTimeInheritance()
 	{
 		return false;
+	}
+
+	@Override
+	public boolean usesOwnAuthorizationSchema()
+	{
+		return true;
 	}
 
 	@NotNull


### PR DESCRIPTION
Related to https://github.com/influxdata/openapi/pull/193:

1.  Removed endpoints without tag => removed `DefaultService`
2. Added new security schemas

## Proposed Changes

1. **Python**:  all `__init__` files are generating - removed `default_service`
1. **Python**: don't uses new authorization schemas because the client uses own definition of authorization header
1. **PHP**: don't uses new authorization schemas because the client uses own definition of authorization header

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] Rebased/mergeable
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
