### PR TITLE
fix(php): nanosecond datetime string convertor

### DIFF
--- a/openapi-generator/src/main/java/com/influxdb/codegen/PostProcessHelper.java
+++ b/openapi-generator/src/main/java/com/influxdb/codegen/PostProcessHelper.java
@@ -31,6 +31,7 @@ import io.swagger.v3.oas.models.parameters.HeaderParameter;
 import io.swagger.v3.oas.models.parameters.Parameter;
 import io.swagger.v3.oas.models.parameters.RequestBody;
 import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -89,7 +90,11 @@ class PostProcessHelper
 		// Drop available security schemas if the client uses own definition of Auth header
 		if (generator.usesOwnAuthorizationSchema())
 		{
-			openAPI.getSecurity().clear();
+			List<SecurityRequirement> security = openAPI.getSecurity();
+			if (security != null)
+			{
+				security.clear();
+			}
 		}
 		
 		//

--- a/openapi-generator/src/main/resources/php/ObjectSerializer.mustache
+++ b/openapi-generator/src/main/resources/php/ObjectSerializer.mustache
@@ -316,6 +316,7 @@ class ObjectSerializer
             return $instance;
         }
     }
+
     /**
     * Nano precision is not supported while decoding RFC 3339 formatted date/times.
     * https://bugs.php.net/bug.php?id=6481
@@ -327,9 +328,9 @@ class ObjectSerializer
     */
     static function fixDatetimeNanos(string $date) : string {
         $dateParts = explode(".", $date);
-        $nanosZ = $dateParts[1];
-        $posZ = strpos($nanosZ, 'Z');
+        $nanosZ = $dateParts[1] ?? "";
         if (strlen($nanosZ) > 9) {
+            $posZ = strpos($nanosZ, 'Z');
             $converted = $dateParts[0] . "." . substr($nanosZ, 0, 8);
             if ($posZ > 0) {
                 $converted .= "Z";
@@ -339,5 +340,4 @@ class ObjectSerializer
             return $date;
         }
     }
-
 }


### PR DESCRIPTION
Related to https://github.com/influxdata/influxdb-client-php/issues/94

## Proposed Changes

Some APIs can return date without nanosecond precision => also supports dates like: `"2021-09-29T06:32:56Z"`.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] Rebased/mergeable
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
