### PR TITLE
fix(java, c#): rename authorization name

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -10,4 +10,4 @@ _Briefly describe your proposed changes:_
 
 - [ ] Rebased/mergeable
 - [ ] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
-- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
+- [ ] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)

--- a/openapi-generator/src/main/java/com/influxdb/codegen/PostProcessHelper.java
+++ b/openapi-generator/src/main/java/com/influxdb/codegen/PostProcessHelper.java
@@ -223,23 +223,19 @@ class PostProcessHelper
 		{
 			openAPI.getPaths().forEach((path, pathItem) -> {
 				pathItem
-						.readOperations()
-						.forEach(operation -> {
-							if (operation != null && operation.getSecurity() != null && !operation.getSecurity().isEmpty())
+						.readOperations().stream().filter(operation -> operation != null && operation.getSecurity() != null && !operation.getSecurity().isEmpty()).forEach(operation -> {
+							boolean containsBasicAuth = operation
+									.getSecurity()
+									.stream()
+									.anyMatch(securityRequirement -> securityRequirement.containsKey("BasicAuth") ||
+											securityRequirement.containsKey("BasicAuthentication"));
+							if (containsBasicAuth)
 							{
-								boolean containsBasicAuth = operation
-										.getSecurity()
-										.stream()
-										.anyMatch(securityRequirement -> securityRequirement.containsKey("BasicAuth"));
-
-								if (containsBasicAuth)
-								{
-									Parameter authorization = new HeaderParameter()
-											.name("Authorization")
-											.schema(new StringSchema())
-											.description("An auth credential for the Basic scheme");
-									operation.addParametersItem(authorization);
-								}
+								Parameter authorization = new HeaderParameter()
+										.name("Authorization")
+										.schema(new StringSchema())
+										.description("An auth credential for the Basic scheme");
+								operation.addParametersItem(authorization);
 							}
 						});
 			});


### PR DESCRIPTION
Related to https://github.com/influxdata/openapi/pull/205/

## Proposed Changes

Added support for named security as `BasicAuthentication`.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] Rebased/mergeable
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
