### PR TITLE
feat(java): use `ResponseBody` as return type for /ping endpoint

### DIFF
--- a/openapi-generator/src/main/java/com/influxdb/codegen/InfluxJavaGenerator.java
+++ b/openapi-generator/src/main/java/com/influxdb/codegen/InfluxJavaGenerator.java
@@ -305,6 +305,13 @@ public class InfluxJavaGenerator extends JavaClientCodegen implements InfluxGene
 					.forEach(operation -> operation.vendorExtensions.put("x-response-streaming", true));
 		}
 
+		//
+		// Add ResponseBody type for /ping endpoint => avaible to read Headers
+		//
+		if (((Map)objs.get("operations")).get("pathPrefix").equals("ping")) {
+			operations.forEach(operation -> operation.returnType = "ResponseBody");
+		}
+
 		return operationsWithModels;
 	}
 


### PR DESCRIPTION
Related to https://github.com/influxdata/influxdb-client-java/pull/272

## Proposed Changes

Use `ResponseBody` as return type for /ping endpoint.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] Rebased/mergeable
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
