### PR TITLE
chore: annotation permission is already present in swagger

### DIFF
--- a/openapi-generator/src/main/java/com/influxdb/codegen/PostProcessHelper.java
+++ b/openapi-generator/src/main/java/com/influxdb/codegen/PostProcessHelper.java
@@ -281,15 +281,6 @@ class PostProcessHelper
 		}
 
 		//
-		// Add missing permission resource type
-		//
-		{
-			Schema resource = openAPI.getComponents().getSchemas().get("Resource");
-			StringSchema type = (StringSchema) resource.getProperties().get("type");
-			type.getEnum().add("annotations");
-		}
-
-		//
 		// Trim description
 		//
 		openAPI.getComponents().getParameters().forEach((s, parameter) -> {


### PR DESCRIPTION
Related to https://github.com/influxdata/openapi/pull/220

## Proposed Changes

Removed appending `annotation` type into `Resource`.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] Rebased/mergeable
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
