### PR TITLE
fix: InfluxQL is already drop

### DIFF
--- a/openapi-generator/src/main/java/com/influxdb/codegen/PostProcessHelper.java
+++ b/openapi-generator/src/main/java/com/influxdb/codegen/PostProcessHelper.java
@@ -96,19 +96,6 @@ class PostProcessHelper
 				security.clear();
 			}
 		}
-		
-		//
-		//
-		// Drop supports for InfluxQL
-		//
-		{
-			RequestBody requestBody = openAPI.getPaths().get("/query").getPost().getRequestBody();
-			MediaType mediaType = requestBody.getContent().get("application/json");
-			// Set correct schema to `Query` object
-			Schema schema = ((ComposedSchema) mediaType.getSchema()).getOneOf().get(0);
-			mediaType.schema(schema);
-			dropSchemas("InfluxQLQuery");
-		}
 
 		//
 		// Use first response type for multiple response type by oneOf (Dashboard, DashboardWithViewProperties)


### PR DESCRIPTION
Related to https://github.com/influxdata/openapi/pull/223

## Proposed Changes

The InfluxQL is dropped from API.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] Rebased/mergeable
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
