### PR TITLE
fix(java): split operation for "write"

### DIFF
--- a/openapi-generator/src/main/java/com/influxdb/codegen/InfluxJavaGenerator.java
+++ b/openapi-generator/src/main/java/com/influxdb/codegen/InfluxJavaGenerator.java
@@ -200,6 +200,7 @@ public class InfluxJavaGenerator extends JavaClientCodegen implements InfluxGene
         //
 		List<CodegenOperation> operationToSplit = operations.stream()
 				.filter(operation -> operation.produces != null && operation.produces.size() > 1)
+				.filter(operation -> !operation.operationId.equals("postWrite"))
 				.collect(Collectors.toList());
 
 		operationToSplit.forEach(operation -> {


### PR DESCRIPTION
Related to https://github.com/influxdata/openapi/pull/242

## Proposed Changes

The post write operation isn't split for "text/html" response type.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] Rebased/mergeable
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
