### PR TITLE
fix(python): timeout can be specified as a float

### DIFF
--- a/openapi-generator/src/main/resources/python/rest.mustache
+++ b/openapi-generator/src/main/resources/python/rest.mustache
@@ -153,7 +153,7 @@ class RESTClientObject(object):
         timeout = None
         _configured_timeout = _request_timeout or self.configuration.timeout
         if _configured_timeout:
-            if isinstance(_configured_timeout, (int, ) if six.PY3 else (int, long)):  # noqa: E501,F821
+            if isinstance(_configured_timeout, (int, float, ) if six.PY3 else (int, long, float, )):  # noqa: E501,F821
                 timeout = urllib3.Timeout(total=_configured_timeout / 1_000)
             elif (isinstance(_configured_timeout, tuple) and
                   len(_configured_timeout) == 2):


### PR DESCRIPTION
Related to https://github.com/influxdata/influxdb-client-python/pull/384

## Proposed Changes

Timeout can be specified as a float.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] Rebased/mergeable
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
