### PR TITLE
chore(python): support Stacks, Templates in generator

### DIFF
--- a/openapi-generator/src/main/java/com/influxdb/codegen/InfluxCSharpGenerator.java
+++ b/openapi-generator/src/main/java/com/influxdb/codegen/InfluxCSharpGenerator.java
@@ -215,6 +215,12 @@ public class InfluxCSharpGenerator extends CSharpClientCodegen implements Influx
 		return false;
 	}
 
+	@Override
+	public boolean supportsStacksTemplates()
+	{
+		return false;
+	}
+
 	@NotNull
 	@Override
 	public Collection<String> getTypeAdapterImports()

--- a/openapi-generator/src/main/java/com/influxdb/codegen/InfluxGenerator.java
+++ b/openapi-generator/src/main/java/com/influxdb/codegen/InfluxGenerator.java
@@ -26,6 +26,8 @@ public interface InfluxGenerator
 
 	boolean usesOwnAuthorizationSchema();
 
+	boolean supportsStacksTemplates();
+
 	@Nonnull
 	Collection<String> getTypeAdapterImports();
 }

--- a/openapi-generator/src/main/java/com/influxdb/codegen/InfluxJavaGenerator.java
+++ b/openapi-generator/src/main/java/com/influxdb/codegen/InfluxJavaGenerator.java
@@ -445,6 +445,12 @@ public class InfluxJavaGenerator extends JavaClientCodegen implements InfluxGene
 		return false;
 	}
 
+	@Override
+	public boolean supportsStacksTemplates()
+	{
+		return false;
+	}
+
 	@NotNull
 	@Override
 	public Collection<String> getTypeAdapterImports()

--- a/openapi-generator/src/main/java/com/influxdb/codegen/InfluxPhpGenerator.java
+++ b/openapi-generator/src/main/java/com/influxdb/codegen/InfluxPhpGenerator.java
@@ -203,6 +203,12 @@ public class InfluxPhpGenerator extends PhpClientCodegen implements InfluxGenera
 		return true;
 	}
 
+	@Override
+	public boolean supportsStacksTemplates()
+	{
+		return false;
+	}
+
 	@NotNull
 	@Override
 	public Collection<String> getTypeAdapterImports()

--- a/openapi-generator/src/main/java/com/influxdb/codegen/InfluxPythonGenerator.java
+++ b/openapi-generator/src/main/java/com/influxdb/codegen/InfluxPythonGenerator.java
@@ -128,6 +128,22 @@ public class InfluxPythonGenerator extends PythonClientCodegen implements Influx
     }
 
 	@Override
+	public String toVarName(String name)
+	{
+		name = name.replaceAll("orgIDs", "orgIds");
+
+		return super.toVarName(name);
+	}
+
+	@Override
+	public String toModelFilename(String name)
+	{
+		name = name.replaceAll("orgIDs", "orgIds");
+
+		return super.toModelFilename(name);
+	}
+
+	@Override
 	public void processOpenAPI(OpenAPI openAPI) {
 
 		List<String> serviceInits = Lists.newArrayList(
@@ -179,6 +195,12 @@ public class InfluxPythonGenerator extends PythonClientCodegen implements Influx
 
 	@Override
 	public boolean usesOwnAuthorizationSchema()
+	{
+		return true;
+	}
+
+	@Override
+	public boolean supportsStacksTemplates()
 	{
 		return true;
 	}


### PR DESCRIPTION
Related to https://github.com/influxdata/influxdb-client-python/pull/399

## Proposed Changes

1. Add possibility to generate api for `Stacks` and `Templates`
2. Fix naming problem for Stacks's generic models 

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] Rebased/mergeable
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
