### PR TITLE
feat(c#): use int64 for Duration magnitude

### DIFF
--- a/openapi-generator/src/main/java/com/influxdb/codegen/InfluxCSharpGenerator.java
+++ b/openapi-generator/src/main/java/com/influxdb/codegen/InfluxCSharpGenerator.java
@@ -60,6 +60,15 @@ public class InfluxCSharpGenerator extends CSharpClientCodegen implements Influx
 
 		postProcessHelper = new PostProcessHelper(this);
 		postProcessHelper.postProcessOpenAPI();
+
+		//
+		// Set duration magnitude as long
+		//
+		{
+			Schema duration = openAPI.getComponents().getSchemas().get("Duration");
+			Schema magnitude = (Schema) duration.getProperties().get("magnitude");
+			magnitude.setFormat("int64");
+		}
 	}
 
 	@Override


### PR DESCRIPTION
Related to https://github.com/influxdata/influxdb-client-csharp/pull/282

## Proposed Changes

Use int64 for Duration magnitude => long type in C#.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] Rebased/mergeable
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
