### PR TITLE
fix: missing InvocableScriptsApi import

### DIFF
--- a/openapi-generator/src/main/java/com/influxdb/codegen/InfluxJavaGenerator.java
+++ b/openapi-generator/src/main/java/com/influxdb/codegen/InfluxJavaGenerator.java
@@ -40,6 +40,7 @@ import io.swagger.v3.oas.models.media.IntegerSchema;
 import io.swagger.v3.oas.models.media.MediaType;
 import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.media.StringSchema;
+import io.swagger.v3.oas.models.responses.ApiResponse;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -210,7 +211,11 @@ public class InfluxJavaGenerator extends JavaClientCodegen implements InfluxGene
 					.filter(produce -> !operation.baseName.equals("Metrics"))
 					.map(produce -> {
 
-						PathItem path = globalOpenAPI.getPaths().get(StringUtils.substringAfter(operation.path, "/v2"));
+						String operationPath = StringUtils.substringAfter(operation.path, "/v2");
+						if (!operationPath.startsWith("/")) {
+							operationPath = "/" + operationPath;
+						}
+						PathItem path = globalOpenAPI.getPaths().get(operationPath);
 
 						Operation apiOperation;
 						switch (operation.httpMethod.toLowerCase())
@@ -225,7 +230,11 @@ public class InfluxJavaGenerator extends JavaClientCodegen implements InfluxGene
 								throw new IllegalStateException();
 						}
 
-						Content content = apiOperation.getResponses().get("200").getContent();
+						ApiResponse apiResponse = apiOperation.getResponses().get("200");
+						if (apiResponse == null) {
+							return "";
+						}
+						Content content = apiResponse.getContent();
 						MediaType mediaType = content.get(produce.get("mediaType"));
 						if (mediaType == null)
 						{

--- a/openapi-generator/src/main/resources/python/__init__package.mustache
+++ b/openapi-generator/src/main/resources/python/__init__package.mustache
@@ -18,6 +18,7 @@ from {{packageName}}.configuration import Configuration
 from influxdb_client.client.authorizations_api import AuthorizationsApi
 from influxdb_client.client.bucket_api import BucketsApi
 from influxdb_client.client.delete_api import DeleteApi
+from influxdb_client.client.invocable_scripts_api import InvocableScriptsApi
 from influxdb_client.client.labels_api import LabelsApi
 from influxdb_client.client.organizations_api import OrganizationsApi
 from influxdb_client.client.query_api import QueryApi


### PR DESCRIPTION
## Proposed Changes

1. Added missing `InvocableScriptsApi` import
2. Fixed generating response type 


## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] Rebased/mergeable
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
