### PR TITLE
feat(java): add WriteConsistency parameter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,6 +52,9 @@ jobs:
       contracts:
         type: string
         default: "oss.yml"
+      definitions:
+        type: string
+        default: "oss.yml --nothing"
     steps:
       - checkout
       - restore_cache:
@@ -72,6 +75,10 @@ jobs:
           name: "Append Cloud definitions"
           command: |
             mvn -f openapi-generator/pom.xml exec:java -Dexec.mainClass="com.influxdb.AppendCloudDefinitions" -Dexec.args="oss.yml cloud.yml"
+      - run:
+          name: "Append Custom definitions << parameters.definitions >>"
+          command: |
+            mvn -f openapi-generator/pom.xml exec:java -Dexec.mainClass="com.influxdb.AppendCustomDefinitions" -Dexec.args="<< parameters.definitions >>"
       - clone-client:
           client: influxdb-client-<< parameters.client >>
           branch: << parameters.branch >>
@@ -320,6 +327,7 @@ workflows:
           name: generate-java
           client: java
           contracts: "oss.yml invocable-scripts.yml"
+          definitions: "oss.yml --write-consistency"
       - generate-client:
           name: generate-php
           client: php

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -289,6 +289,7 @@ workflows:
           name: generate-java
           client: java
           contracts: "oss.yml invocable-scripts.yml"
+          definitions: "oss.yml --write-consistency"
       - generate-client:
           name: generate-php
           client: php

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,7 @@ generate-java:
 	@docker-compose run download-invocable-scripts
 	@docker-compose run java mvn -f ./openapi-generator/pom.xml compile exec:java -Dexec.mainClass="com.influxdb.MergeContracts" -Dexec.args="oss.yml invocable-scripts.yml"
 	@docker-compose run java mvn -f ./openapi-generator/pom.xml compile exec:java -Dexec.mainClass="com.influxdb.AppendCloudDefinitions" -Dexec.args="oss.yml cloud.yml"
+	@docker-compose run java mvn -f ./openapi-generator/pom.xml compile exec:java -Dexec.mainClass="com.influxdb.AppendCustomDefinitions" -Dexec.args="oss.yml --write-consistency"
 	@docker-compose run java ./generate-java.sh
 
 check-java:

--- a/openapi-generator/src/main/java/com/influxdb/AppendCloudDefinitions.java
+++ b/openapi-generator/src/main/java/com/influxdb/AppendCloudDefinitions.java
@@ -52,7 +52,7 @@ public class AppendCloudDefinitions
 		LOG.info("Updated: " + args[0]);
 	}
 
-	private static <T> T mapValue(String[] paths, Object object)
+	protected static <T> T mapValue(String[] paths, Object object)
 	{
 		if (paths.length == 0)
 		{

--- a/openapi-generator/src/main/java/com/influxdb/AppendCustomDefinitions.java
+++ b/openapi-generator/src/main/java/com/influxdb/AppendCustomDefinitions.java
@@ -1,0 +1,61 @@
+package com.influxdb;
+
+import java.io.FileInputStream;
+import java.io.FileWriter;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Logger;
+
+import org.yaml.snakeyaml.Yaml;
+
+/**
+ * @author Jakub Bednar (04/08/2022 10:16)
+ */
+public class AppendCustomDefinitions
+{
+	private static final Logger LOG = Logger.getLogger(AppendCustomDefinitions.class.getName());
+
+	public static void main(String[] args) throws Exception
+	{
+		if (args.length < 2)
+		{
+			LOG.info("You have to specify paths for 'oss.yml' and requested definition e.g. '--write-consistency'.");
+			return;
+		}
+
+		Yaml yaml = new Yaml();
+		Map<String, Object> oss = yaml.load(new FileInputStream(args[0]));
+		if (Arrays.asList(args).contains("--write-consistency"))
+		{
+			// create WriteConsistency schema
+			LinkedHashMap<String, Object> writeConsistencySchema = new LinkedHashMap<>();
+			writeConsistencySchema.put("type", "string");
+			writeConsistencySchema.put("enum", Arrays.asList("any","one","quorum","all"));
+
+			Map<String, Object> schemas = AppendCloudDefinitions.mapValue(new String[]{"components", "schemas"}, oss);
+			schemas.put("WriteConsistency", writeConsistencySchema);
+			List<Map<String, Object>> parameters = AppendCloudDefinitions.mapValue(new String[]{"paths", "/write", "post", "parameters"}, oss);
+
+			// append WriteConsistency parameter into /write
+			boolean present = parameters.stream().anyMatch(it -> "consistency".equals(it.get("name")));
+			if (!present)
+			{
+				LinkedHashMap<String, Object> writeConsistencyParam = new LinkedHashMap<>();
+				writeConsistencyParam.put("in", "query");
+				writeConsistencyParam.put("name", "consistency");
+				writeConsistencyParam.put("description", "Sets the write consistency for the point. InfluxDB assumes that the write consistency is 'one' if you do not specify. Available with InfluxDB Enterprise clusters only.");
+				writeConsistencyParam.put("schema", Collections.singletonMap("$ref", "#/components/schemas/WriteConsistency"));
+
+				parameters.add(writeConsistencyParam);
+			}
+			
+			LOG.info("Appended 'write-consistency' to: " + args[0]);
+		}
+
+		// write to output
+		yaml.dump(oss, new FileWriter(args[0]));
+	}
+}


### PR DESCRIPTION
Related to https://github.com/influxdata/influxdb-client-java/pull/329

## Proposed Changes

Add possibility to specify `WriteConsistency` parameter. For more info see:

- https://docs.influxdata.com/influxdb/v1.8/tools/api/#query-string-parameters-2
- https://docs.influxdata.com/enterprise_influxdb/v1.6/concepts/clustering/#write-consistency

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] Rebased/mergeable
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
