### PR TITLE
fix(python): redact the Authorization HTTP header from log

### DIFF
--- a/openapi-generator/src/main/resources/python/configuration.mustache
+++ b/openapi-generator/src/main/resources/python/configuration.mustache
@@ -5,7 +5,6 @@
 from __future__ import absolute_import
 
 import copy
-import http.client as httplib
 import logging
 import multiprocessing
 import sys
@@ -159,17 +158,19 @@ class Configuration(object, metaclass=TypeWithDefault):
         self.__debug = value
         if self.__debug:
             # if debug status is True, turn on debug logging
-            for _, logger in self.loggers.items():
+            for name, logger in self.loggers.items():
                 logger.setLevel(logging.DEBUG)
-            # turn on httplib debug
-            httplib.HTTPConnection.debuglevel = 1
+                if name == 'influxdb_client.client.http':
+                    logger.addHandler(logging.StreamHandler(sys.stdout))
+            # we use 'influxdb_client.client.http' logger instead of this
+            # httplib.HTTPConnection.debuglevel = 1
         else:
             # if debug status is False, turn off debug logging,
             # setting log level to default `logging.WARNING`
             for _, logger in self.loggers.items():
                 logger.setLevel(logging.WARNING)
-            # turn off httplib debug
-            httplib.HTTPConnection.debuglevel = 0
+            # we use 'influxdb_client.client.http' logger instead of this
+            # httplib.HTTPConnection.debuglevel = 0
 
     @property
     def logger_format(self):

--- a/openapi-generator/src/main/resources/python/rest.mustache
+++ b/openapi-generator/src/main/resources/python/rest.mustache
@@ -11,6 +11,7 @@ import ssl
 from urllib.parse import urlencode
 
 from influxdb_client.rest import ApiException
+from influxdb_client.rest import _BaseRESTClient
 
 try:
     import urllib3
@@ -156,6 +157,11 @@ class RESTClientObject(object):
         if 'Content-Type' not in headers:
             headers['Content-Type'] = 'application/json'
 
+        if self.configuration.debug:
+            _BaseRESTClient.log_request(method, f"{url}?{urlencode(query_params)}")
+            _BaseRESTClient.log_headers(headers, '>>>')
+            _BaseRESTClient.log_body(body, '>>>')
+
         try:
             # For `POST`, `PUT`, `PATCH`, `OPTIONS`, `DELETE`
             if method in ['POST', 'PUT', 'PATCH', 'OPTIONS', 'DELETE']:
@@ -230,6 +236,14 @@ class RESTClientObject(object):
             # In the python 3, the response.data is bytes.
             # we need to decode it to string.
             r.data = r.data.decode('utf8')
+
+        if self.configuration.debug:
+            _BaseRESTClient.log_response(r.status)
+            if hasattr(r, 'headers'):
+                _BaseRESTClient.log_headers(r.headers, '<<<')
+            if hasattr(r, 'urllib3_response'):
+                _BaseRESTClient.log_headers(r.urllib3_response.headers, '<<<')
+            _BaseRESTClient.log_body(r.data, '<<<')
 
         if not 200 <= r.status <= 299:
             raise ApiException(http_resp=r)

--- a/openapi-generator/src/main/resources/python/rest_async.mustache
+++ b/openapi-generator/src/main/resources/python/rest_async.mustache
@@ -9,22 +9,23 @@ from urllib.parse import urlencode
 import aiohttp
 
 from influxdb_client.rest import ApiException
+from influxdb_client.rest import _BaseRESTClient
 from influxdb_client.rest import _UTF_8_encoding
 
 
 async def _on_request_start(session, trace_config_ctx, params):
-    print(f">>> Request: '{params.method} {params.url}'")
-    print(f">>> Headers: '{params.headers}'")
+    _BaseRESTClient.log_request(params.method, params.url)
+    _BaseRESTClient.log_headers(params.headers, '>>>')
 
 
 async def _on_request_chunk_sent(session, context, params):
     if params.chunk:
-        print(f">>> Body: {params.chunk}")
+        _BaseRESTClient.log_body(params.chunk, '>>>')
 
 
 async def _on_request_end(session, trace_config_ctx, params):
-    print(f"<<< Response: {params.response.status}")
-    print(f"<<< Headers: '{params.response.headers}")
+    _BaseRESTClient.log_response(params.response.status)
+    _BaseRESTClient.log_headers(params.headers, '<<<')
 
     response_content = params.response.content
     data = bytearray()
@@ -34,7 +35,7 @@ async def _on_request_end(session, trace_config_ctx, params):
             break
         data += chunk
     if data:
-        print(f"<<< Body: {data.decode(_UTF_8_encoding)}")
+        _BaseRESTClient.log_body(data.decode(_UTF_8_encoding), '<<<')
         response_content.unread_data(data=data)
 
 

--- a/openapi-generator/src/main/resources/python/rest_commons.mustache
+++ b/openapi-generator/src/main/resources/python/rest_commons.mustache
@@ -3,6 +3,9 @@
 {{>partial_header}}
 from __future__ import absolute_import
 
+import logging
+from typing import Dict
+
 from influxdb_client.client.exceptions import InfluxDBError
 from influxdb_client.configuration import Configuration
 
@@ -42,6 +45,30 @@ class ApiException(InfluxDBError):
             error_message += "HTTP response body: {0}\n".format(self.body)
 
         return error_message
+
+
+class _BaseRESTClient(object):
+    logger = logging.getLogger('influxdb_client.client.http')
+
+    @staticmethod
+    def log_request(method: str, url: str):
+        _BaseRESTClient.logger.debug(f">>> Request: '{method} {url}'")
+
+    @staticmethod
+    def log_response(status: str):
+        _BaseRESTClient.logger.debug(f"<<< Response: {status}")
+
+    @staticmethod
+    def log_body(body: object, prefix: str):
+        _BaseRESTClient.logger.debug(f"{prefix} Body: {body}")
+
+    @staticmethod
+    def log_headers(headers: Dict[str, str], prefix: str):
+        for key, v in headers.items():
+            value = v
+            if 'authorization' == key.lower():
+                value = '***'
+            _BaseRESTClient.logger.debug(f"{prefix} {key}: {value}")
 
 
 def _requires_create_user_session(configuration: Configuration, cookie: str, resource_path: str):


### PR DESCRIPTION
Related to https://github.com/influxdata/influxdb-client-python/pull/462

## Proposed Changes

Redacted `Authorisation` header from HTTP requests.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] Rebased/mergeable
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
