### PR TITLE
fix(java,cshharp): UserResponse.oAuthID isn't returned by the response anymore in either cloud or oss

### DIFF
--- a/influxdb-client-csharp.patch
+++ b/influxdb-client-csharp.patch
@@ -1,5 +1,5 @@
 diff --git a/Client.Test/ItBucketsApiTest.cs b/Client.Test/ItBucketsApiTest.cs
-index 0eef7d9..5cc68ff 100644
+index 0eef7d9..561fbdd 100644
 --- a/Client.Test/ItBucketsApiTest.cs
 +++ b/Client.Test/ItBucketsApiTest.cs
 @@ -53,7 +53,7 @@ namespace InfluxDB.Client.Test
@@ -7,7 +7,7 @@ index 0eef7d9..5cc68ff 100644
              Assert.AreEqual(name, cloned.Name);
              Assert.AreEqual(_organization.Id, cloned.OrgID);
 -            Assert.IsNull(cloned.Rp);
-+            Assert.AreEqual(0, cloned.Rp);
++            Assert.AreEqual("0", cloned.Rp);
              Assert.AreEqual(1, cloned.RetentionRules.Count);
              Assert.AreEqual(3600, cloned.RetentionRules[0].EverySeconds);
              Assert.AreEqual(BucketRetentionRules.TypeEnum.Expire, cloned.RetentionRules[0].Type);

--- a/influxdb-client-csharp.patch
+++ b/influxdb-client-csharp.patch
@@ -1,3 +1,16 @@
+diff --git a/Client.Test/ItBucketsApiTest.cs b/Client.Test/ItBucketsApiTest.cs
+index 0eef7d9..5cc68ff 100644
+--- a/Client.Test/ItBucketsApiTest.cs
++++ b/Client.Test/ItBucketsApiTest.cs
+@@ -53,7 +53,7 @@ namespace InfluxDB.Client.Test
+ 
+             Assert.AreEqual(name, cloned.Name);
+             Assert.AreEqual(_organization.Id, cloned.OrgID);
+-            Assert.IsNull(cloned.Rp);
++            Assert.AreEqual(0, cloned.Rp);
+             Assert.AreEqual(1, cloned.RetentionRules.Count);
+             Assert.AreEqual(3600, cloned.RetentionRules[0].EverySeconds);
+             Assert.AreEqual(BucketRetentionRules.TypeEnum.Expire, cloned.RetentionRules[0].Type);
 diff --git a/Client/UsersApi.cs b/Client/UsersApi.cs
 index bb4899a..cbf0283 100644
 --- a/Client/UsersApi.cs

--- a/influxdb-client-csharp.patch
+++ b/influxdb-client-csharp.patch
@@ -1,5 +1,5 @@
 diff --git a/Client/UsersApi.cs b/Client/UsersApi.cs
-index bb4899a..7f82854 100644
+index bb4899a..cbf0283 100644
 --- a/Client/UsersApi.cs
 +++ b/Client/UsersApi.cs
 @@ -366,7 +366,7 @@ namespace InfluxDB.Client
@@ -7,7 +7,7 @@ index bb4899a..7f82854 100644
          {
              Enum.TryParse(user.Status.ToString(), true, out PostUser.StatusEnum status);
 -            var postUser = new PostUser(user.OauthID, user.Name, status);
-+            var postUser = new PostUser(user.Name, status);
++            var postUser = new PostUser(name: user.Name, status: status);
              return postUser;
          }
      }

--- a/influxdb-client-csharp.patch
+++ b/influxdb-client-csharp.patch
@@ -1,0 +1,13 @@
+diff --git a/Client/UsersApi.cs b/Client/UsersApi.cs
+index bb4899a..7f82854 100644
+--- a/Client/UsersApi.cs
++++ b/Client/UsersApi.cs
+@@ -366,7 +366,7 @@ namespace InfluxDB.Client
+         private PostUser ToPostUser(User user)
+         {
+             Enum.TryParse(user.Status.ToString(), true, out PostUser.StatusEnum status);
+-            var postUser = new PostUser(user.OauthID, user.Name, status);
++            var postUser = new PostUser(user.Name, status);
+             return postUser;
+         }
+     }

--- a/influxdb-client-java.patch
+++ b/influxdb-client-java.patch
@@ -1,0 +1,20 @@
+diff --git a/client/src/main/java/com/influxdb/client/internal/UsersApiImpl.java b/client/src/main/java/com/influxdb/client/internal/UsersApiImpl.java
+index b841ac27c2..8be6a7eb82 100644
+--- a/client/src/main/java/com/influxdb/client/internal/UsersApiImpl.java
++++ b/client/src/main/java/com/influxdb/client/internal/UsersApiImpl.java
+@@ -96,7 +96,6 @@ final class UsersApiImpl extends AbstractRestClient implements UsersApi {
+         Arguments.checkNotNull(user, "User");
+ 
+         PostUser request = new PostUser()
+-                .oauthID(user.getOauthID())
+                 .name(user.getName())
+                 .status(PostUser.StatusEnum.fromValue(user.getStatus().getValue()));
+ 
+@@ -112,7 +111,6 @@ final class UsersApiImpl extends AbstractRestClient implements UsersApi {
+         Arguments.checkNotNull(user, "User");
+ 
+         PostUser request = new PostUser()
+-                .oauthID(user.getOauthID())
+                 .name(user.getName())
+                 .status(PostUser.StatusEnum.fromValue(user.getStatus().getValue()));
+ 


### PR DESCRIPTION
Related to https://github.com/influxdata/openapi/pull/472

## Proposed Changes

Add patches to fix build the `java` and the `csharp` client

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] Rebased/mergeable
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
