### PR TITLE
fix: PostUsers Password is not authorized via http basic

### DIFF
--- a/influxdb-client-csharp.patch
+++ b/influxdb-client-csharp.patch
@@ -11,6 +11,58 @@ index 0eef7d9..561fbdd 100644
              Assert.AreEqual(1, cloned.RetentionRules.Count);
              Assert.AreEqual(3600, cloned.RetentionRules[0].EverySeconds);
              Assert.AreEqual(BucketRetentionRules.TypeEnum.Expire, cloned.RetentionRules[0].Type);
+diff --git a/Client.Test/ItUsersApiTest.cs b/Client.Test/ItUsersApiTest.cs
+index 5c7307b..5cc929c 100644
+--- a/Client.Test/ItUsersApiTest.cs
++++ b/Client.Test/ItUsersApiTest.cs
+@@ -1,4 +1,3 @@
+-using System;
+ using System.Linq;
+ using System.Threading.Tasks;
+ using InfluxDB.Client.Core.Exceptions;
+@@ -109,36 +108,32 @@ namespace InfluxDB.Client.Test
+         }
+ 
+         [Test]
+-        [Property("basic_auth", "true")]
+-        [Ignore("TODO not implemented set password https://github.com/influxdata/influxdb/pull/15981")]
+         public async Task UpdatePassword()
+         {
+             var user = await _usersApi.MeAsync();
+             Assert.IsNotNull(user);
+ 
+-            await _usersApi.UpdateUserPasswordAsync(user, "my-password", "my-password");
++            await _usersApi.UpdateUserPasswordAsync(user, "my-password");
+         }
+ 
+         [Test]
+-        [Property("basic_auth", "true")]
+-        [Ignore("TODO not implemented set password https://github.com/influxdata/influxdb/pull/15981")]
+         public async Task UpdatePasswordById()
+         {
+             var user = await _usersApi.MeAsync();
+             Assert.IsNotNull(user);
+ 
+-            await _usersApi.UpdateUserPasswordAsync(user.Id, "my-password", "my-password");
++            await _usersApi.UpdateUserPasswordAsync(user.Id, "my-password");
+         }
+ 
+         [Test]
+         public void UpdatePasswordNotFound()
+         {
+-            var ioe = Assert.ThrowsAsync<AggregateException>(async () =>
+-                await _usersApi.UpdateUserPasswordAsync("020f755c3c082000", "", "new-password"));
++            var ioe = Assert.ThrowsAsync<ForbiddenException>(async () =>
++                await _usersApi.UpdateUserPasswordAsync("020f755c3c082000", "new-password"));
+ 
+             Assert.IsNotNull(ioe);
+-            Assert.AreEqual("user not found", ioe.InnerException.Message);
+-            Assert.AreEqual(typeof(NotFoundException), ioe.InnerException.GetType());
++            Assert.AreEqual("your userID is incorrect", ioe.Message);
++            Assert.AreEqual(typeof(ForbiddenException), ioe.GetType());
+         }
+ 
+         [Test]
 diff --git a/Client/InvokableScriptsApi.cs b/Client/InvokableScriptsApi.cs
 index 79f4b06..a1921fd 100644
 --- a/Client/InvokableScriptsApi.cs
@@ -25,10 +77,113 @@ index 79f4b06..a1921fd 100644
          }
  
 diff --git a/Client/UsersApi.cs b/Client/UsersApi.cs
-index bb4899a..cbf0283 100644
+index bb4899a..a5a920e 100644
 --- a/Client/UsersApi.cs
 +++ b/Client/UsersApi.cs
-@@ -366,7 +366,7 @@ namespace InfluxDB.Client
+@@ -39,22 +39,20 @@ namespace InfluxDB.Client
+         /// Update password to an user.
+         /// </summary>
+         /// <param name="user">user to update password</param>
+-        /// <param name="oldPassword">old password</param>
+         /// <param name="newPassword">new password</param>
+         /// <param name="cancellationToken">Cancellation token</param>
+         /// <returns>user updated</returns>
+-        Task UpdateUserPasswordAsync(User user, string oldPassword, string newPassword,
++        Task UpdateUserPasswordAsync(User user, string newPassword,
+             CancellationToken cancellationToken = default);
+ 
+         /// <summary>
+         /// Update password to an user.
+         /// </summary>
+         /// <param name="userId">ID of user to update password</param>
+-        /// <param name="oldPassword">old password</param>
+         /// <param name="newPassword">new password</param>
+         /// <param name="cancellationToken">Cancellation token</param>
+         /// <returns>user updated</returns>
+-        Task UpdateUserPasswordAsync(string userId, string oldPassword, string newPassword,
++        Task UpdateUserPasswordAsync(string userId, string newPassword,
+             CancellationToken cancellationToken = default);
+ 
+         /// <summary>
+@@ -152,7 +150,7 @@ namespace InfluxDB.Client
+         {
+             Arguments.CheckNonEmptyString(name, nameof(name));
+ 
+-            var user = new User(name: name);
++            var user = new User(name);
+ 
+             return CreateUserAsync(user, cancellationToken);
+         }
+@@ -187,37 +185,33 @@ namespace InfluxDB.Client
+         /// Update password to an user.
+         /// </summary>
+         /// <param name="user">user to update password</param>
+-        /// <param name="oldPassword">old password</param>
+         /// <param name="newPassword">new password</param>
+         /// <param name="cancellationToken">Cancellation token</param>
+         /// <returns>user updated</returns>
+-        public Task UpdateUserPasswordAsync(User user, string oldPassword, string newPassword,
++        public Task UpdateUserPasswordAsync(User user, string newPassword,
+             CancellationToken cancellationToken = default)
+         {
+             Arguments.CheckNotNull(user, nameof(user));
+-            Arguments.CheckNotNull(oldPassword, nameof(oldPassword));
+             Arguments.CheckNotNull(newPassword, nameof(newPassword));
+ 
+-            return UpdateUserPasswordAsync(user.Id, user.Name, oldPassword, newPassword, cancellationToken);
++            return UpdateUserPasswordAsync(user.Id, newPassword, cancellationToken);
+         }
+ 
+         /// <summary>
+         /// Update password to an user.
+         /// </summary>
+         /// <param name="userId">ID of user to update password</param>
+-        /// <param name="oldPassword">old password</param>
+         /// <param name="newPassword">new password</param>
+         /// <param name="cancellationToken">Cancellation token</param>
+         /// <returns>user updated</returns>
+-        public Task UpdateUserPasswordAsync(string userId, string oldPassword, string newPassword,
++        public Task UpdateUserPasswordAsync(string userId, string newPassword,
+             CancellationToken cancellationToken = default)
+         {
+             Arguments.CheckNotNull(userId, nameof(userId));
+-            Arguments.CheckNotNull(oldPassword, nameof(oldPassword));
+             Arguments.CheckNotNull(newPassword, nameof(newPassword));
+ 
+-            return FindUserByIdAsync(userId, cancellationToken)
+-                .ContinueWith(t => UpdateUserPasswordAsync(t.Result, oldPassword, newPassword), cancellationToken);
++            return _service.PostUsersIDPasswordAsync(userId, new PasswordResetBody(newPassword), null,
++                cancellationToken);
+         }
+ 
+         /// <summary>
+@@ -276,7 +270,7 @@ namespace InfluxDB.Client
+             Arguments.CheckNonEmptyString(clonedName, nameof(clonedName));
+             Arguments.CheckNotNull(user, nameof(user));
+ 
+-            var cloned = new User(name: clonedName);
++            var cloned = new User(clonedName);
+ 
+             return CreateUserAsync(cloned, cancellationToken);
+         }
+@@ -349,24 +343,10 @@ namespace InfluxDB.Client
+             return response._Users;
+         }
+ 
+-        private Task UpdateUserPasswordAsync(string userId, string userName, string oldPassword,
+-            string newPassword, CancellationToken cancellationToken = default)
+-        {
+-            Arguments.CheckNotNull(userId, nameof(userId));
+-            Arguments.CheckNotNull(userName, nameof(userName));
+-            Arguments.CheckNotNull(oldPassword, nameof(oldPassword));
+-            Arguments.CheckNotNull(newPassword, nameof(newPassword));
+-
+-            var header = InfluxDBClient.AuthorizationHeader(userName, oldPassword);
+-
+-            return _service.PostUsersIDPasswordAsync(userId, new PasswordResetBody(newPassword), null, header,
+-                cancellationToken);
+-        }
+-
          private PostUser ToPostUser(User user)
          {
              Enum.TryParse(user.Status.ToString(), true, out PostUser.StatusEnum status);

--- a/influxdb-client-java.patch
+++ b/influxdb-client-java.patch
@@ -1,3 +1,30 @@
+diff --git a/client/src/main/java/com/influxdb/client/UsersApi.java b/client/src/main/java/com/influxdb/client/UsersApi.java
+index 8da414e64f..1bf4c843f0 100644
+--- a/client/src/main/java/com/influxdb/client/UsersApi.java
++++ b/client/src/main/java/com/influxdb/client/UsersApi.java
+@@ -66,22 +66,18 @@ public interface UsersApi {
+      * Update password to an user.
+      *
+      * @param user        user to update password
+-     * @param oldPassword old password
+      * @param newPassword new password
+      */
+     void updateUserPassword(@Nonnull final User user,
+-                            @Nonnull final String oldPassword,
+                             @Nonnull final String newPassword);
+ 
+     /**
+      * Update password to an user.
+      *
+      * @param userID      ID of user to update password
+-     * @param oldPassword old password
+      * @param newPassword new password
+      */
+     void updateUserPassword(@Nonnull final String userID,
+-                            @Nonnull final String oldPassword,
+                             @Nonnull final String newPassword);
+ 
+     /**
 diff --git a/client/src/main/java/com/influxdb/client/internal/InvokableScriptsApiImpl.java b/client/src/main/java/com/influxdb/client/internal/InvokableScriptsApiImpl.java
 index 8f66707f70..cd96ad47ad 100644
 --- a/client/src/main/java/com/influxdb/client/internal/InvokableScriptsApiImpl.java
@@ -12,7 +39,7 @@ index 8f66707f70..cd96ad47ad 100644
          return execute(call).getScripts();
      }
 diff --git a/client/src/main/java/com/influxdb/client/internal/UsersApiImpl.java b/client/src/main/java/com/influxdb/client/internal/UsersApiImpl.java
-index b841ac27c2..8be6a7eb82 100644
+index b841ac27c2..e6d2c5054a 100644
 --- a/client/src/main/java/com/influxdb/client/internal/UsersApiImpl.java
 +++ b/client/src/main/java/com/influxdb/client/internal/UsersApiImpl.java
 @@ -96,7 +96,6 @@ final class UsersApiImpl extends AbstractRestClient implements UsersApi {
@@ -31,3 +58,140 @@ index b841ac27c2..8be6a7eb82 100644
                  .name(user.getName())
                  .status(PostUser.StatusEnum.fromValue(user.getStatus().getValue()));
  
+@@ -123,29 +121,25 @@ final class UsersApiImpl extends AbstractRestClient implements UsersApi {
+ 
+     @Override
+     public void updateUserPassword(@Nonnull final User user,
+-                                   @Nonnull final String oldPassword,
+                                    @Nonnull final String newPassword) {
+ 
+         Arguments.checkNotNull(user, "User");
+-        Arguments.checkNotNull(oldPassword, "old password");
+         Arguments.checkNotNull(newPassword, "new password");
+ 
+-        updateUserPassword(user.getId(), user.getName(), oldPassword, newPassword);
++        updateUserPassword(user.getId(), newPassword);
+     }
+ 
+     @Override
+     public void updateUserPassword(@Nonnull final String userID,
+-                                   @Nonnull final String oldPassword,
+                                    @Nonnull final String newPassword) {
+ 
+         Arguments.checkNotNull(userID, "User ID");
+-        Arguments.checkNotNull(oldPassword, "old password");
+         Arguments.checkNotNull(newPassword, "new password");
+ 
+-        Call<User> userByID = service.getUsersID(userID, null);
+-        User user = execute(userByID);
++        PasswordResetBody resetBody = new PasswordResetBody().password(newPassword);
++        Call<Void> call = service.postUsersIDPassword(userID, resetBody, null);
+ 
+-        updateUserPassword(userID, user.getName(), oldPassword, newPassword);
++        execute(call);
+     }
+ 
+     @Override
+@@ -216,22 +210,4 @@ final class UsersApiImpl extends AbstractRestClient implements UsersApi {
+ 
+         execute(call);
+     }
+-
+-    private void updateUserPassword(@Nonnull final String userID,
+-                                    @Nonnull final String userName,
+-                                    @Nonnull final String oldPassword,
+-                                    @Nonnull final String newPassword) {
+-
+-        Arguments.checkNotNull(userID, "User ID");
+-        Arguments.checkNotNull(userName, "Username");
+-        Arguments.checkNotNull(oldPassword, "old password");
+-        Arguments.checkNotNull(newPassword, "new password");
+-
+-        String credentials = Credentials.basic(userName, oldPassword);
+-
+-        PasswordResetBody resetBody = new PasswordResetBody().password(newPassword);
+-        Call<Void> call = service.postUsersIDPassword(userID, resetBody, null, credentials);
+-
+-        execute(call);
+-    }
+ }
+\ No newline at end of file
+diff --git a/client/src/test/java/com/influxdb/client/ITUsersApi.java b/client/src/test/java/com/influxdb/client/ITUsersApi.java
+index 50ecf32fb8..4397397dd9 100644
+--- a/client/src/test/java/com/influxdb/client/ITUsersApi.java
++++ b/client/src/test/java/com/influxdb/client/ITUsersApi.java
+@@ -122,13 +122,14 @@ class ITUsersApi extends AbstractITClientTest {
+     void updateUser() {
+ 
+         User createdUser = usersApi.createUser(generateName("John Ryzen"));
+-        createdUser.setName("Tom Push");
++        String newName = generateName("Tom Push");
++        createdUser.setName(newName);
+ 
+         User updatedUser = usersApi.updateUser(createdUser);
+ 
+         Assertions.assertThat(updatedUser).isNotNull();
+         Assertions.assertThat(updatedUser.getId()).isEqualTo(createdUser.getId());
+-        Assertions.assertThat(updatedUser.getName()).isEqualTo("Tom Push");
++        Assertions.assertThat(updatedUser.getName()).isEqualTo(newName);
+     }
+ 
+     @Test
+@@ -169,51 +170,37 @@ class ITUsersApi extends AbstractITClientTest {
+     }
+ 
+     @Test
+-    @Tag("basic_auth")
+-    @Disabled("TODO not implemented set password https://github.com/influxdata/influxdb/pull/15981")
+     void updatePassword() {
+ 
+         User user = usersApi.me();
+         Assertions.assertThat(user).isNotNull();
+ 
+-        usersApi.updateUserPassword(user, "my-password", "my-password");
++        usersApi.updateUserPassword(user, "my-password");
+     }
+ 
+-    //TODO set user password -> https://github.com/influxdata/influxdb/issues/11590
+     @Test
+-    @Disabled
+     void createNewUserAndSetPassword() throws Exception {
+ 
+         User myNewUser = usersApi.createUser(generateName("My new user"));
+ 
+-        influxDBClient.close();
+-
+-        //TODO set user password -> https://github.com/influxdata/influxdb/issues/11590
+-        influxDBClient = InfluxDBClientFactory.create(influxDB_URL, "my-user", "my-password".toCharArray());
+-        usersApi = influxDBClient.getUsersApi();
+-
+-        usersApi.updateUserPassword(myNewUser, "", "strong-password");
++        influxDBClient.getUsersApi().updateUserPassword(myNewUser, "strong-password");
+     }
+ 
+     @Test
+-    @Tag("basic_auth")
+-    @Disabled("TODO not implemented set password https://github.com/influxdata/influxdb/pull/15981")
+     void updatePasswordNotFound() {
+ 
+-        Assertions.assertThatThrownBy(() -> usersApi.updateUserPassword("020f755c3c082000", "", "new-password"))
+-                .isInstanceOf(NotFoundException.class)
+-                .hasMessage("user not found");
++        Assertions.assertThatThrownBy(() -> usersApi.updateUserPassword("020f755c3c082000", "new-password"))
++                .isInstanceOf(ForbiddenException.class)
++                .hasMessageContaining("your userID is incorrect");
+     }
+ 
+     @Test
+-    @Tag("basic_auth")
+-    @Disabled("TODO not implemented set password https://github.com/influxdata/influxdb/pull/15981")
+     void updatePasswordById() {
+ 
+         User user = usersApi.me();
+         Assertions.assertThat(user).isNotNull();
+ 
+-        usersApi.updateUserPassword(user.getId(), "my-password", "my-password");
++        usersApi.updateUserPassword(user.getId(), "my-password");
+     }
+ 
+     @Test

--- a/openapi-generator/src/main/java/com/influxdb/codegen/PostProcessHelper.java
+++ b/openapi-generator/src/main/java/com/influxdb/codegen/PostProcessHelper.java
@@ -343,11 +343,19 @@ class PostProcessHelper
 											securityRequirement.containsKey("BasicAuthentication"));
 							if (containsBasicAuth)
 							{
-								Parameter authorization = new HeaderParameter()
-										.name("Authorization")
-										.schema(new StringSchema())
-										.description("An auth credential for the Basic scheme");
-								operation.addParametersItem(authorization);
+								// the BasicAuth is not required for this operation
+								if (operation.getOperationId().equals("PostUsersIDPassword"))
+								{
+									operation.security(null);
+								}
+								else
+								{
+									Parameter authorization = new HeaderParameter()
+											.name("Authorization")
+											.schema(new StringSchema())
+											.description("An auth credential for the Basic scheme");
+									operation.addParametersItem(authorization);
+								}
 							}
 						});
 			});


### PR DESCRIPTION
Related to https://github.com/influxdata/influxdb-client-python/pull/498

## Proposed Changes

Removed basic auth from `PostUsersPassword` operation.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] Rebased/mergeable
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
