### PR TITLE
fix(python): duplicated debug output

### DIFF
--- a/openapi-generator/src/main/resources/python/configuration.mustache
+++ b/openapi-generator/src/main/resources/python/configuration.mustache
@@ -166,7 +166,10 @@ class Configuration(object, metaclass=TypeWithDefault):
             for name, logger in self.loggers.items():
                 logger.setLevel(logging.DEBUG)
                 if name == 'influxdb_client.client.http':
-                    logger.addHandler(logging.StreamHandler(sys.stdout))
+                    # makes sure to do not duplicate stdout handler
+                    if not any(map(lambda h: isinstance(h, logging.StreamHandler) and h.stream == sys.stdout,
+                                   logger.handlers)):
+                        logger.addHandler(logging.StreamHandler(sys.stdout))
             # we use 'influxdb_client.client.http' logger instead of this
             # httplib.HTTPConnection.debuglevel = 1
         else:


### PR DESCRIPTION
Related to https://github.com/influxdata/influxdb-client-python/pull/521

## Proposed Changes

The `logging.StreamHandler(sys.stdout)` should appended only once into `Logger`.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] Rebased/mergeable
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
