### PR TITLE
fix(python): HTTP request return type for Management API [async/await]

### DIFF
--- a/openapi-generator/src/main/resources/python/api_client_async.mustache
+++ b/openapi-generator/src/main/resources/python/api_client_async.mustache
@@ -182,8 +182,8 @@ class ApiClientAsync(object):
                 return_data = None
 
 {{^tornado}}
-        if _return_http_data_only:
-            return (return_data)
+        if _return_http_data_only is not False:
+            return return_data
         else:
             return (return_data, response_data.status,
                     response_data.getheaders())
@@ -658,7 +658,7 @@ class ApiClientAsync(object):
 
     async def _signin(self, resource_path: str):
         if _requires_create_user_session(self.configuration, self.cookie, resource_path):
-            http_info = await SigninService(self).post_signin_async()
+            http_info = await SigninService(self).post_signin_async(_return_http_data_only=False)
             self.cookie = http_info[2]['set-cookie']
 
     async def _signout(self):


### PR DESCRIPTION
Related to https://github.com/influxdata/influxdb-client-python/pull/531

## Proposed Changes

This PR fixes the return type for `*_async(...)` methods in management API. The async management API returns required object not `tuple` with HTTP status and headers.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] Rebased/mergeable
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
