### PR TITLE
fix: AuthorizationsAPI changed to AuthorizationsAPITokensAPI

### DIFF
--- a/influxdb-client-csharp.patch
+++ b/influxdb-client-csharp.patch
@@ -76,6 +76,32 @@ index 79f4b06..a1921fd 100644
                  .ContinueWith(t => t.Result._Scripts, cancellationToken);
          }
  
+diff --git a/Client/TasksApi.cs b/Client/TasksApi.cs
+index 98c4276..0993046 100644
+--- a/Client/TasksApi.cs
++++ b/Client/TasksApi.cs
+@@ -531,8 +531,8 @@ namespace InfluxDB.Client
+             Arguments.CheckNotNull(task, nameof(task));
+ 
+             var status = (TaskStatusType)Enum.Parse(typeof(TaskStatusType), task.Status.ToString());
+-            var taskCreateRequest = new TaskCreateRequest(task.OrgID, task.Org, status,
+-                task.Flux, task.Description);
++            var taskCreateRequest = new TaskCreateRequest(orgID: task.OrgID, org: task.Org, status: status,
++                flux: task.Flux, description: task.Description);
+ 
+             return CreateTaskAsync(taskCreateRequest, cancellationToken);
+         }
+@@ -733,8 +733,8 @@ namespace InfluxDB.Client
+             Arguments.CheckNotNull(task, nameof(task));
+ 
+             var status = (TaskStatusType)Enum.Parse(typeof(TaskStatusType), task.Status.ToString());
+-            var cloned = new TaskCreateRequest(task.OrgID, task.Org, status,
+-                task.Flux, task.Description);
++            var cloned = new TaskCreateRequest(orgID: task.OrgID, org: task.Org, status: status,
++                flux: task.Flux, description: task.Description);
+ 
+             var created = await CreateTaskAsync(cloned, cancellationToken).ConfigureAwait(false);
+             var labels = await GetLabelsAsync(task, cancellationToken).ConfigureAwait(false);
 diff --git a/Client/UsersApi.cs b/Client/UsersApi.cs
 index bb4899a..a5a920e 100644
 --- a/Client/UsersApi.cs
@@ -192,3 +218,34 @@ index bb4899a..a5a920e 100644
              return postUser;
          }
      }
+diff --git a/Client/WriteApiAsync.cs b/Client/WriteApiAsync.cs
+index b64249c..0483f75 100644
+--- a/Client/WriteApiAsync.cs
++++ b/Client/WriteApiAsync.cs
+@@ -415,9 +415,9 @@ namespace InfluxDB.Client
+                 return Task.CompletedTask;
+             }
+ 
+-            return _service.PostWriteAsync(org, bucket, Encoding.UTF8.GetBytes(sb.ToString()), null,
+-                PostHeaderEncoding, PostHeaderContentType, null, PostHeaderAccept, null, precision,
+-                cancellationToken);
++            return _service.PostWriteAsync(org: org, bucket: bucket, body: Encoding.UTF8.GetBytes(sb.ToString()),
++                contentEncoding: PostHeaderEncoding, contentType: PostHeaderContentType, accept: PostHeaderAccept,
++                precision: precision, cancellationToken: cancellationToken);
+         }
+ 
+         private Task<RestResponse> WriteDataAsyncWithIRestResponse(IEnumerable<BatchWriteData> batch,
+@@ -433,9 +433,10 @@ namespace InfluxDB.Client
+ 
+             var sb = ToLineProtocolBody(batch);
+ 
+-            return _service.PostWriteAsyncWithIRestResponse(org, bucket, Encoding.UTF8.GetBytes(sb.ToString()), null,
+-                PostHeaderEncoding, PostHeaderContentType, null, PostHeaderAccept, null, precision,
+-                cancellationToken);
++            return _service.PostWriteAsyncWithIRestResponse(org: org, bucket: bucket,
++                body: Encoding.UTF8.GetBytes(sb.ToString()), contentEncoding: PostHeaderEncoding,
++                contentType: PostHeaderContentType, accept: PostHeaderAccept, precision: precision,
++                cancellationToken: cancellationToken);
+         }
+ 
+         private static StringBuilder ToLineProtocolBody(IEnumerable<BatchWriteData> data)

--- a/influxdb-client-java.patch
+++ b/influxdb-client-java.patch
@@ -25,6 +25,19 @@ index 8da414e64f..1bf4c843f0 100644
                              @Nonnull final String newPassword);
  
      /**
+diff --git a/client/src/main/java/com/influxdb/client/internal/AuthorizationsApiImpl.java b/client/src/main/java/com/influxdb/client/internal/AuthorizationsApiImpl.java
+index f658bc6a4a..b9d9e683aa 100644
+--- a/client/src/main/java/com/influxdb/client/internal/AuthorizationsApiImpl.java
++++ b/client/src/main/java/com/influxdb/client/internal/AuthorizationsApiImpl.java
+@@ -234,7 +234,7 @@ final class AuthorizationsApiImpl extends AbstractRestClient implements Authoriz
+                                                    @Nullable final String userName,
+                                                    @Nullable final String orgID) {
+ 
+-        Call<Authorizations> authorizationsCall = service.getAuthorizations(null, userID, userName, orgID, null);
++        Call<Authorizations> authorizationsCall = service.getAuthorizations(null, userID, userName, orgID, null, null);
+ 
+         Authorizations authorizations = execute(authorizationsCall);
+         LOG.log(Level.FINEST, "findAuthorizations found: {0}", authorizations);
 diff --git a/client/src/main/java/com/influxdb/client/internal/InvokableScriptsApiImpl.java b/client/src/main/java/com/influxdb/client/internal/InvokableScriptsApiImpl.java
 index 8f66707f70..cd96ad47ad 100644
 --- a/client/src/main/java/com/influxdb/client/internal/InvokableScriptsApiImpl.java
@@ -117,10 +130,10 @@ index b841ac27c2..e6d2c5054a 100644
  }
 \ No newline at end of file
 diff --git a/client/src/test/java/com/influxdb/client/ITUsersApi.java b/client/src/test/java/com/influxdb/client/ITUsersApi.java
-index 50ecf32fb8..4397397dd9 100644
+index 1456cd2ae6..71aa8acdc2 100644
 --- a/client/src/test/java/com/influxdb/client/ITUsersApi.java
 +++ b/client/src/test/java/com/influxdb/client/ITUsersApi.java
-@@ -122,13 +122,14 @@ class ITUsersApi extends AbstractITClientTest {
+@@ -119,13 +119,14 @@ class ITUsersApi extends AbstractITClientTest {
      void updateUser() {
  
          User createdUser = usersApi.createUser(generateName("John Ryzen"));
@@ -137,7 +150,7 @@ index 50ecf32fb8..4397397dd9 100644
      }
  
      @Test
-@@ -169,51 +170,37 @@ class ITUsersApi extends AbstractITClientTest {
+@@ -166,51 +167,37 @@ class ITUsersApi extends AbstractITClientTest {
      }
  
      @Test

--- a/openapi-generator/src/main/java/com/influxdb/codegen/PostProcessHelper.java
+++ b/openapi-generator/src/main/java/com/influxdb/codegen/PostProcessHelper.java
@@ -338,10 +338,10 @@ class PostProcessHelper
 			});
 		}
 
-		//
-		// Authorization header for operation with Basic Security
-		//
 		{
+			//
+			// Authorization header for operation with Basic Security
+			//
 			openAPI.getPaths().forEach((path, pathItem) -> {
 				pathItem
 						.readOperations().stream().filter(operation -> operation != null && operation.getSecurity() != null && !operation.getSecurity().isEmpty()).forEach(operation -> {
@@ -367,6 +367,15 @@ class PostProcessHelper
 								}
 							}
 						});
+
+				//
+				// Keep Authorization API name to 'Authorizations'
+				//
+				for (Operation operation : pathItem.readOperations()) {
+					operation
+							.getTags()
+							.replaceAll(tag -> tag.replace("Authorizations (API tokens)", "Authorizations"));
+				}
 			});
 		}
 
@@ -408,6 +417,8 @@ class PostProcessHelper
 			StringSchema type = (StringSchema) telegrafPlugin.getProperties().get("type");
 			type._enum(Arrays.asList("input", "output"));
 		}
+
+//		openAPI.getTags().get(0).setName("Authorizations");
 
 		//
 		// Trim description


### PR DESCRIPTION
Related to influxdata/openapi#602

## Proposed Changes

Keep authorization API named as `AuthorizationsAPI`

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] Rebased/mergeable
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
