### PR TITLE
refactor(python): use `HTTResponse.headers` instead deprecated `HTTPResponse.getheaders()`

### DIFF
--- a/openapi-generator/src/main/resources/python/rest.mustache
+++ b/openapi-generator/src/main/resources/python/rest.mustache
@@ -35,7 +35,7 @@ class RESTResponse(io.IOBase):
 
     def getheaders(self):
         """Return a dictionary of the response headers."""
-        return self.urllib3_response.getheaders()
+        return self.urllib3_response.headers
 
     def getheader(self, name, default=None):
         """Return a given response header."""


### PR DESCRIPTION
Related to https://github.com/influxdata/influxdb-client-python/pull/534/

## Proposed Changes

Refactor code to not deprecated variant:

![image](https://user-images.githubusercontent.com/455137/203901663-44727c71-68f4-49fe-867a-b70e2abb3c97.png)


## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] Rebased/mergeable
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
