### PR TITLE
fix(c#): parsing HTTP headers with duplicated name

### DIFF
--- a/openapi-generator/src/main/resources/csharp/ApiResponse.mustache
+++ b/openapi-generator/src/main/resources/csharp/ApiResponse.mustache
@@ -1,0 +1,48 @@
+{{>partial_header}}
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace {{packageName}}.Client
+{
+    /// <summary>
+    /// API Response
+    /// </summary>
+    {{>visibility}} class ApiResponse<T>
+    {
+        /// <summary>
+        /// Gets or sets the status code (HTTP status code)
+        /// </summary>
+        /// <value>The status code.</value>
+        public int StatusCode { get; private set; }
+
+        /// <summary>
+        /// Gets or sets the HTTP headers
+        /// </summary>
+        /// <value>HTTP headers</value>
+        public IDictionary<string, string> Headers { get; private set; }
+
+        /// <summary>
+        /// Gets or sets the data (parsed HTTP body)
+        /// </summary>
+        /// <value>The data.</value>
+        public T Data { get; private set; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ApiResponse&lt;T&gt;" /> class.
+        /// </summary>
+        /// <param name="statusCode">HTTP status code.</param>
+        /// <param name="headers">HTTP headers.</param>
+        /// <param name="data">Data (parsed HTTP body)</param>
+        public ApiResponse(int statusCode, IEnumerable<(string Name, object Value)> headers, T data)
+        {
+            this.StatusCode= statusCode;
+            this.Headers = headers
+                .GroupBy(h => h.Name)
+	            .ToDictionary(g => g.Key, g => g.FirstOrDefault().Value.ToString());
+            this.Data = data;
+        }
+
+    }
+
+}

--- a/openapi-generator/src/main/resources/csharp/api.mustache
+++ b/openapi-generator/src/main/resources/csharp/api.mustache
@@ -301,12 +301,12 @@ namespace {{packageName}}.{{apiPackage}}
 
             {{#returnType}}
             return new ApiResponse<{{{returnType}}}>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.{{^netStandard}}Name{{/netStandard}}{{#netStandard}}Key{{/netStandard}}, x => x.Value.ToString()),
+                localVarResponse.Headers.Select(h => (h.Name, h.Value)),
                 ({{{returnType}}}) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof({{#returnContainer}}{{{returnContainer}}}{{/returnContainer}}{{^returnContainer}}{{{returnType}}}{{/returnContainer}})));
             {{/returnType}}
             {{^returnType}}
             return new ApiResponse<Object>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.{{^netStandard}}Name{{/netStandard}}{{#netStandard}}Key{{/netStandard}}, x => x.Value.ToString()),
+                localVarResponse.Headers.Select(h => (h.Name, h.Value)),
                 null);
             {{/returnType}}
         }
@@ -680,12 +680,12 @@ namespace {{packageName}}.{{apiPackage}}
 
             {{#returnType}}
             return new ApiResponse<{{{returnType}}}>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.{{^netStandard}}Name{{/netStandard}}{{#netStandard}}Key{{/netStandard}}, x => x.Value.ToString()),
+                localVarResponse.Headers.Select(h => (h.Name, h.Value)),
                 ({{{returnType}}}) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof({{#returnContainer}}{{{returnContainer}}}{{/returnContainer}}{{^returnContainer}}{{{returnType}}}{{/returnContainer}})));
             {{/returnType}}
             {{^returnType}}
             return new ApiResponse<Object>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.{{^netStandard}}Name{{/netStandard}}{{#netStandard}}Key{{/netStandard}}, x => x.Value.ToString()),
+                localVarResponse.Headers.Select(h => (h.Name, h.Value)),
                 null);
             {{/returnType}}
         }


### PR DESCRIPTION
Related to https://github.com/influxdata/influxdb-client-csharp/pull/426

## Proposed Changes

This PR fixes parsing HTTP response with duplicated HTTP header.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] Rebased/mergeable
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
